### PR TITLE
chore(repo): gitignore agent scratch and worktree roots BL-848 ~5mins

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,5 @@ pages-*
 cypress*
 .vscode
 .github
+.agents/temp*
+.agents/worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ playwright/.auth
 .github/agents-temp/*
 !.github/agents-temp/README.md
 .agents/temp*
+# .agents/worktrees holds live git worktrees - never git clean -fdx here
 .agents/worktrees/
 .playwright-mcp
 

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ playwright/.auth
 # Agent temp files (checkpoints, drafts)
 .github/agents-temp/*
 !.github/agents-temp/README.md
+.agents/temp*
+.agents/worktrees/
 .playwright-mcp
 
 .claude


### PR DESCRIPTION
### Problem

`.agents/temp` (agent scratch) and `.agents/worktrees` (agent worktrees) are not gitignored in this repo, so both show as untracked. During PR #70 a review agent cleaning up its own scratch deleted another session's files from that directory mid-run.

### Resolution

Ignore `.agents/temp*` and `.agents/worktrees` in `.gitignore` and `.dockerignore`, alongside the existing `.github/agents-temp` rule. Also restores the missing trailing newline on `.dockerignore`.

### Evidence

`git check-ignore -v .agents/temp/session-drupal-auth/pr-body.md` resolves to `.gitignore:55`, and `git status` no longer reports `.agents/` as untracked. No source file is touched.

<details><summary>Full details</summary>

## Stacked on

Based on `fix/BL-848-drupal-auth-flood-backoff` (PR #70), since that branch is where the problem surfaced. Review and merge #70 first.

## LOC Breakdown

| Category | Files | LOC (added) | Review est. |
| --- | --- | --- | --- |
| Config (ignore rules) | 2 | 5 | — |
| **Total impl** | 2 | 5 | **5 min** |

Ignore-file lines carry no logic, so they fall outside the review budget; the 5-minute floor applies.

## Changed files

| File | Change |
| --- | --- |
| `.gitignore` | Add `.agents/temp*` and `.agents/worktrees/` |
| `.dockerignore` | Add `.agents/temp*` and `.agents/worktrees`; restore trailing newline |

## Why both files

The harness convention is that `.agents/temp*` is both git- and docker-ignored: scratch must never be committed, and must never be copied into a build context. This repo had neither rule.

## Testing

- [x] `git check-ignore -v` confirms the rule matches a real scratch path
- [x] `git status` clean with scratch present on disk
- [x] `git show --name-status` confirms the commit touches only the two ignore files
- [x] `.dockerignore` tail verified: `.github` intact on its own line

</details>
