### PR TITLE
chore: gitignore generated coverage output BL-884 ~5mins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ tmp
 .playwright-mcp/
 graphify-out
 backlog.jsonl
+coverage/


### PR DESCRIPTION
### Problem

`coverage/` is not in `.gitignore`. Every `yarn test:coverage` run leaves the generated report in the working tree, so it has to be moved or deleted by hand before committing.

### Resolution

Add `coverage/` to `.gitignore`. One line.

### Evidence

`yarn test:run` is unchanged at 17 failed / 309 passed before and after, with the same failure set. `git status --porcelain` is clean after a `yarn test:coverage` run. Code review and security review both returned Approve with no findings above Nit.

<details><summary>Full details</summary>

**Jira:** [BL-884](https://scbd.atlassian.net/browse/BL-884) (epic [BL-880](https://scbd.atlassian.net/browse/BL-880))

## LOC Breakdown

| Category | LOC | Review est. |
| --- | --- | --- |
| Config tweaks | 1 | — |
| **Total impl** | 0 | **5 min** |

> **Review estimate:** ~5 min - [methodology](https://gist.github.com/randyhoulahan/d9b22ccebaa37370a57d53f406e012da).

Floor applied: `.gitignore` is a config tweak and contributes 0 to the review budget.

## Verification

| Check | Result |
| --- | --- |
| `yarn test:run` on base | 17 failed / 309 passed |
| `yarn test:run` after change | 17 failed / 309 passed, failure set identical |
| `yarn test:coverage` then `git status --porcelain` | clean |
| `git ls-files coverage/` before change | empty — nothing tracked becomes ignored |
| Independence vs `bsl-2026-04` | pass |
| lint / typecheck | N/A — no such script in this repo |

The 17 failures are pre-existing on the base branch: `tests/unit/server/middleware/cache-control.test.js` fails with `CACHE_TTL is not defined`, a missing Nuxt auto-import in the plain-node Vitest env. Neither that test nor `server/middleware/cache-control.js` is in scope here.

## Review

Both passes ran on the branch diff before this PR was opened. One cycle, clean.

- **Code review** — Approve. Confirmed the diff is one file / one insertion; confirmed `vitest.config.ts` sets no `coverage.reportsDirectory`, so the v8 provider writes to `<root>/coverage` and the pattern matches; confirmed no source directory named `coverage` exists, so nothing is shadowed.
- **Security** — Approve, no findings. No secrets, env files, dependency, lockfile, or CI/workflow changes. Nothing under `coverage/` was ever tracked, so nothing previously visible is concealed and no scanned path drops out. No new gitleaks findings beyond the repo's 24-finding baseline in `i18n/locales` and gitignored `.nuxt/dev`.

## Context

First of five PRs from the `themeing-front-end` plan. This one is standalone hygiene — the plan's later tasks run `yarn test:coverage` to prove resolver coverage, and without this they each have to hand-move the output before committing.

</details>


[BL-884]: https://scbd.atlassian.net/browse/BL-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-880]: https://scbd.atlassian.net/browse/BL-880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ