### PR TITLE
chore: BL-883 fail fast when local e2e env vars are missing ~5mins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,10 +26,14 @@ I18N_DB_CONNECTION_LIMIT=5
 
 # Public Runtime Configuration
 #
-# REQUIRED for `yarn dev` and `yarn test:e2e`: NUXT_PUBLIC_ENV,
-# NUXT_PUBLIC_MULTI_SITE_CODE and NUXT_PUBLIC_BASE_HOST default to "" in
-# nuxt.config.ts and have no fallback. If any is empty every request fails with
-# "getSiteSettings cache key missing required context". The values below work as-is.
+# NUXT_PUBLIC_ENV, NUXT_PUBLIC_MULTI_SITE_CODE and NUXT_PUBLIC_BASE_HOST default
+# to "" in nuxt.config.ts and have no fallback. Both `yarn dev` and `yarn test:e2e`
+# require all three: if any is empty, every request fails with
+# "getSiteSettings cache key missing required context".
+# Only `yarn test:e2e` enforces this, failing fast and naming what is missing.
+# `yarn dev` still starts, then fails per-request with that opaque error.
+# The values may come from this file or from the exported environment.
+# The values below work as-is.
 
 # multisite specific
 NUXT_PUBLIC_MULTI_SITE_CODE=bsl

--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ I18N_DB_NAME=i18n_cache
 I18N_DB_CONNECTION_LIMIT=5
 
 # Public Runtime Configuration
+#
+# REQUIRED for `yarn dev` and `yarn test:e2e`: NUXT_PUBLIC_ENV,
+# NUXT_PUBLIC_MULTI_SITE_CODE and NUXT_PUBLIC_BASE_HOST default to "" in
+# nuxt.config.ts and have no fallback. If any is empty every request fails with
+# "getSiteSettings cache key missing required context". The values below work as-is.
 
 # multisite specific
 NUXT_PUBLIC_MULTI_SITE_CODE=bsl

--- a/README.md
+++ b/README.md
@@ -196,6 +196,23 @@ Staging Drupal                     Local Dev Server
 
 ### Quick Setup
 
+> **A root `.env` is mandatory before `yarn test:e2e` will run at all.** A fresh clone or a new git
+> worktree does not have one (`.env` is git-ignored), and without it the Playwright `webServer`
+> still binds its port while every request fails with
+> `getSiteSettings cache key missing required context: env=, multiSiteCode=`. Playwright surfaces
+> that only as a 120-second `webServer` timeout, which hides the real cause.
+>
+> `NUXT_PUBLIC_ENV`, `NUXT_PUBLIC_MULTI_SITE_CODE`, and `NUXT_PUBLIC_BASE_HOST` default to `""` in
+> `nuxt.config.ts` with no fallback, so they must come from the environment. The committed
+> `.env.example` already carries working values for all three:
+>
+> ```bash
+> cp .env.example .env   # then fill in the API credentials
+> ```
+>
+> `playwright.config.ts` now checks this up front and fails immediately, naming the missing
+> variables, instead of timing out.
+
 1. **Configure `.env`** (see `.env.example` for template):
    ```bash
    NUXT_E2E_DRUPAL_URL=<your_staging_url>

--- a/README.md
+++ b/README.md
@@ -196,21 +196,22 @@ Staging Drupal                     Local Dev Server
 
 ### Quick Setup
 
-> **A root `.env` is mandatory before `yarn test:e2e` will run at all.** A fresh clone or a new git
-> worktree does not have one (`.env` is git-ignored), and without it the Playwright `webServer`
-> still binds its port while every request fails with
+> **`yarn test:e2e` will not start until three public runtime variables are set.** A fresh clone or
+> a new git worktree has none of them (`.env` is git-ignored), and without them the Playwright
+> `webServer` still binds its port while every request fails with
 > `getSiteSettings cache key missing required context: env=, multiSiteCode=`. Playwright surfaces
 > that only as a 120-second `webServer` timeout, which hides the real cause.
 >
 > `NUXT_PUBLIC_ENV`, `NUXT_PUBLIC_MULTI_SITE_CODE`, and `NUXT_PUBLIC_BASE_HOST` default to `""` in
-> `nuxt.config.ts` with no fallback, so they must come from the environment. The committed
-> `.env.example` already carries working values for all three:
+> `nuxt.config.ts` with no fallback, so they must come from the environment. Locally that means a
+> root `.env`; in CI, exported variables or injected secrets work just as well and no `.env` file is
+> needed. The committed `.env.example` already carries working values for all three:
 >
 > ```bash
 > cp .env.example .env   # then fill in the API credentials
 > ```
 >
-> `playwright.config.ts` now checks this up front and fails immediately, naming the missing
+> `playwright.config.ts` now checks these up front and fails immediately, naming the missing
 > variables, instead of timing out.
 
 1. **Configure `.env`** (see `.env.example` for template):

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,11 @@ import { defineConfig, devices } from '@playwright/test'
 import type { ConfigOptions } from '@nuxt/test-utils/playwright'
 
 import { getE2EBaseURL } from './tests/e2e/e2e-targets'
+import { assertE2EEnv } from './tests/e2e/assert-e2e-env'
+
+// Fail fast on a missing or incomplete .env. Without it `nuxt dev` still binds its port,
+// but every request throws and Playwright surfaces that only as a 120s webServer timeout.
+assertE2EEnv()
 
 export default defineConfig<ConfigOptions>({
   testDir: "./tests/e2e",

--- a/tests/e2e/assert-e2e-env.ts
+++ b/tests/e2e/assert-e2e-env.ts
@@ -20,34 +20,35 @@ const EXAMPLE_PATH = fileURLToPath(new URL('../../.env.example', import.meta.url
 /**
  * Verify the local e2e prerequisites before Playwright starts its `webServer`.
  *
- * Without a populated `.env`, `nuxt dev` still boots and binds its port, but every
+ * Without the three variables above, `nuxt dev` still boots and binds its port, but every
  * request throws `getSiteSettings cache key missing required context: env=, multiSiteCode=`.
  * Playwright reports that only as a 120s `webServer` timeout, which hides the real cause.
  * Failing here turns a two-minute mystery into an immediate, actionable message.
  *
+ * A root `.env` is a convenience, not a requirement. It is loaded when present, and a variable
+ * already exported in the process environment — a CI secret, for example — satisfies the check
+ * on its own, with no `.env` on disk.
+ *
+ * This is a presence check, not a validation one: a set-but-wrong value passes here and is left
+ * to fail later, at the point that actually knows what a valid value looks like.
+ *
  * Never prints a value — variable names only.
  */
 export function assertE2EEnv (): void {
-  if (!existsSync(ENV_PATH)) {
-    throw new Error(
-      `Local e2e requires a .env at the repo root; none found.\n` +
-      `Fix: cp ${EXAMPLE_PATH} ${ENV_PATH} and fill in the API credentials.\n` +
-      `The committed .env.example already carries working defaults for ${REQUIRED_VARS.join(', ')}.`,
-    )
-  }
-
   // Playwright's own process does not load .env; Nuxt does that for the dev server.
-  // Load it here purely so the check below can see the values.
-  dotenv.config({ path: ENV_PATH, quiet: true })
+  // Load it here purely so the check below can see the values. Absent is fine — the
+  // variables may already be exported by the shell or injected by a CI secret store.
+  if (existsSync(ENV_PATH)) dotenv.config({ path: ENV_PATH, quiet: true })
 
   const missing = REQUIRED_VARS.filter(name => !process.env[name]?.trim())
 
-  if (missing.length > 0) {
-    throw new Error(
-      `Local e2e is missing required environment variables: ${missing.join(', ')}.\n` +
-      `These have no default in nuxt.config.ts, so an empty value makes every request fail with\n` +
-      `"getSiteSettings cache key missing required context".\n` +
-      `Fix: set them in ${ENV_PATH} — see ${EXAMPLE_PATH} for working values.`,
-    )
-  }
+  if (missing.length === 0) return
+
+  throw new Error(
+    `Local e2e is missing required environment variables: ${missing.join(', ')}.\n` +
+    `These have no default in nuxt.config.ts, so an empty value makes every request fail with\n` +
+    `"getSiteSettings cache key missing required context".\n` +
+    `Fix: export them, or set them in a root .env (cp ${EXAMPLE_PATH} ${ENV_PATH}).\n` +
+    `The committed .env.example already carries working values for all three.`,
+  )
 }

--- a/tests/e2e/assert-e2e-env.ts
+++ b/tests/e2e/assert-e2e-env.ts
@@ -1,0 +1,53 @@
+import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import dotenv from 'dotenv'
+
+/**
+ * Public runtime-config values that `nuxt.config.ts` deliberately defaults to `""`.
+ * They can only arrive from the environment, and the server context resolver
+ * (`server/utils/context-unified.ts`) needs all three to build a cache key.
+ */
+const REQUIRED_VARS = [
+  'NUXT_PUBLIC_ENV',
+  'NUXT_PUBLIC_MULTI_SITE_CODE',
+  'NUXT_PUBLIC_BASE_HOST',
+] as const
+
+const ENV_PATH = fileURLToPath(new URL('../../.env', import.meta.url))
+const EXAMPLE_PATH = fileURLToPath(new URL('../../.env.example', import.meta.url))
+
+/**
+ * Verify the local e2e prerequisites before Playwright starts its `webServer`.
+ *
+ * Without a populated `.env`, `nuxt dev` still boots and binds its port, but every
+ * request throws `getSiteSettings cache key missing required context: env=, multiSiteCode=`.
+ * Playwright reports that only as a 120s `webServer` timeout, which hides the real cause.
+ * Failing here turns a two-minute mystery into an immediate, actionable message.
+ *
+ * Never prints a value — variable names only.
+ */
+export function assertE2EEnv (): void {
+  if (!existsSync(ENV_PATH)) {
+    throw new Error(
+      `Local e2e requires a .env at the repo root; none found.\n` +
+      `Fix: cp ${EXAMPLE_PATH} ${ENV_PATH} and fill in the API credentials.\n` +
+      `The committed .env.example already carries working defaults for ${REQUIRED_VARS.join(', ')}.`,
+    )
+  }
+
+  // Playwright's own process does not load .env; Nuxt does that for the dev server.
+  // Load it here purely so the check below can see the values.
+  dotenv.config({ path: ENV_PATH, quiet: true })
+
+  const missing = REQUIRED_VARS.filter(name => !process.env[name]?.trim())
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Local e2e is missing required environment variables: ${missing.join(', ')}.\n` +
+      `These have no default in nuxt.config.ts, so an empty value makes every request fail with\n` +
+      `"getSiteSettings cache key missing required context".\n` +
+      `Fix: set them in ${ENV_PATH} — see ${EXAMPLE_PATH} for working values.`,
+    )
+  }
+}


### PR DESCRIPTION
### Problem

`yarn test:e2e` could not run locally. The dev server booted, then every request died on `getSiteSettings cache key missing required context: env=, multiSiteCode=`. Playwright showed that only as a 120-second `webServer` timeout, so the real cause was invisible.

### Resolution

Fail fast instead. A preflight checks the three required variables before Playwright starts, names the missing ones, and says how to fix it. The prerequisite is now documented.

### Evidence

The harness starts and executes specs. Unit tests unchanged at 17 failed / 309 passed. Preflight proven in three cases: exported with no `.env` passes, fully absent throws naming all three, partial throws naming exactly the missing ones. Code review Approve with comments, security Approve, 2 cycles.

<details><summary>Full details</summary>

**Jira:** [BL-883](https://scbd.atlassian.net/browse/BL-883) (epic [BL-880](https://scbd.atlassian.net/browse/BL-880))

## Root cause

`nuxt.config.ts:76-78` sets `public.env`, `public.baseHost`, and `public.multiSiteCode` to literal `""` with no `process.env` read, unlike every neighbouring key. Those values can only arrive from a root `.env`, which is gitignored at `.gitignore:22-24` and so is absent in a fresh clone or a new worktree.

Proof: with no `.env` the failure reproduces verbatim. Copying a `.env` in and changing nothing else returns HTTP 200.

**This disproved the plan's assumption.** The plan blamed `playwright.config.ts` for skipping the `dev` script's cleanup or selecting the wrong dotenv file. That config was never defective, so the first step here was diagnosis rather than the assumed fix.

## What the fix is, and is not

A preflight is not a functional repair. Nuxt's convention is that `runtimeConfig.public` defaults are placeholders overridden by `NUXT_PUBLIC_*`, so `""` is idiomatic. The real gap is that nothing fails loudly when the override never arrives.

This fixes the reported symptom at the test-harness boundary, which is where the task scoped it. The same opaque failure still hits `yarn dev`, and a durable fix belongs in `nuxt.config.ts` or a Nitro startup assertion. That is filed separately rather than smuggled in here.

`.env` is a convenience, not a requirement. It loads when present, and `dotenv` runs without `override`, so an exported variable or an injected CI secret wins and satisfies the check with no file on disk.

## LOC Breakdown

| Category | LOC | Review est. |
| --- | --- | --- |
| Implementation (test harness) | 54 | 1.8 min |
| Config tweaks | 5 | — |
| Docs | 27 | — |
| **Total impl** | 54 | **5 min** |

> **Review estimate:** ~5 min - [methodology](https://gist.github.com/randyhoulahan/d9b22ccebaa37370a57d53f406e012da).

Floor applied. Skim pace: this is test scaffolding, not business logic.

## Verification

| Check | Result |
| --- | --- |
| `yarn test:run` base | 326 = 17 failed / 309 passed |
| `yarn test:run` after | 326 = 17 failed / 309 passed, unchanged |
| Preflight, exported vars and no `.env` | passes |
| Preflight, neither exported nor present | throws, naming all three |
| Preflight, only one var set | throws, naming exactly the other two |
| Values printed in any case | none — variable names only |
| Diff scope | 4 files, nothing under `app/`, `server/`, or `nuxt.config.ts` |
| Independence vs `bsl-2026-04` | pass |
| lint / typecheck | N/A — no such script in this repo |

Vitest is scoped to `tests/unit/**`, and none of the four changed files fall in or are imported by that tree, so the unit totals could not move. The 17 failures are pre-existing on the base branch: `tests/unit/server/middleware/cache-control.test.js` fails with `CACHE_TTL is not defined`.

## The e2e run, stated honestly

The full sweep was 105 enumerated, 36 passed, 32 failed, 1 skipped, and **36 not observed to run**.

The harness now starts and executes specs. It does not follow that the suite is healthy.

- The 32 failures are a target mismatch, not a harness fault. `home.test.ts:11` and much of `tests/e2e/bl-576-bsl/` assert Biosafety Seed (GT) content while the default target is the `e2e` tenant. Tenancy resolves from the request Host via `baseURL`. Filed separately; changing the default would ripple across all 18 spec files.
- The 36 that never ran are unexplained, with no `maxFailures` configured. That suggests an interrupted run or a dead worker. It is not counted as evidence here.

## Review

Two cycles.

- **Cycle 1, code review** — Approve with comments. The reviewer independently verified the diagnosis by reading `nuxt.config.ts:76-78` and `.gitignore:22-24`, confirmed the preflight is a legitimate seam-respecting fix rather than a paper-over, and accepted the new helper file as the right home for the logic. One Major, two Minors, one Nit.
- **Cycle 1, security** — Approve, no findings. Confirmed no `.env` in the diff or anywhere in branch history, and that both error paths emit variable names only with no `process.env` dump. gitleaks over the commit range found no leaks.
- **Cycle 2** — all four addressed. The Major was the important one: the original `existsSync` gate made a root `.env` file mandatory even when the variables were already exported, which contradicted the code's own error message and would break any CI runner injecting them as secrets. The order is now inverted.

The reviewer also corrected the original explanation of the e2e failures. `nuxt dev --host` sets the bind address, not the Host header. The wording above reflects the corrected mechanism.

## Context

Third of five PRs from the `themeing-front-end` plan. Local e2e was a known blocker in the earlier version of this work and was promoted to a planned task here, because staging is out of scope by directive and is no longer available as an escape hatch.

</details>


[BL-883]: https://scbd.atlassian.net/browse/BL-883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-880]: https://scbd.atlassian.net/browse/BL-880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ