### PR TITLE
refactor: BL-881 route every head theme read through one crash-safe resolver ~11mins

### DIFF
--- a/app/components/page/header/hero-image.vue
+++ b/app/components/page/header/hero-image.vue
@@ -109,12 +109,12 @@
 
     // Color tint — blends with the image via mix-blend-mode: color
     const tintStyle = computed(() => ({
-        background: `linear-gradient(0deg, rgb(${hexToRgb(siteStore?.theme?.hero?.primary[1])}) 0%, rgb(${hexToRgb(siteStore?.theme?.hero?.primary[0])}) 100%)`
+        background: `linear-gradient(0deg, rgb(${hexToRgb(siteStore.theme.hero.primary[1])}) 0%, rgb(${hexToRgb(siteStore.theme.hero.primary[0])}) 100%)`
     }))
 
     // Normal overlays — dark top vignette + left-side primary fade
     const overlayStyle = computed(() => ({
-        background: `linear-gradient(rgba(0, 0, 0, 0.33) 0%, rgba(0, 0, 0, 0) 100%), linear-gradient(90deg, rgb(${hexToRgb(siteStore?.theme?.hero?.primary[0])}) 0%, rgba(${hexToRgb(siteStore?.theme?.hero?.primary[0])}, 0) 100%)`
+        background: `linear-gradient(rgba(0, 0, 0, 0.33) 0%, rgba(0, 0, 0, 0) 100%), linear-gradient(90deg, rgb(${hexToRgb(siteStore.theme.hero.primary[0])}) 0%, rgba(${hexToRgb(siteStore.theme.hero.primary[0])}, 0) 100%)`
     }))
 
     function editUrl() {

--- a/app/components/page/header/language-bar.vue
+++ b/app/components/page/header/language-bar.vue
@@ -48,8 +48,11 @@
     const limitedMenus    = ref([]);
     const otherMenus      = ref([]);
     const viewport        = useViewport();
-    // An unset maxLangBeforeWrap means "never wrap". Feeding undefined straight into the splice()
-    // calls below silently emptied the entire language menu, so fall back to "show everything".
+    // resolveTheme deliberately leaves maxLangBeforeWrap undefined when no leg authors it, and its
+    // contract makes the unset behaviour the caller's to choose (see app/utils/resolve-theme.js).
+    // Here that choice is "never wrap". The old code passed undefined straight into the splice()
+    // calls below; splice returns the elements it REMOVED, and a deleteCount of undefined coerces
+    // to 0, so limitedMenus came back empty and the entire language menu vanished.
     const limit           = ref(siteStore.maxLangBeforeWrap ?? Number.MAX_SAFE_INTEGER);
     const query           = computed(()=> route.query);
     const isBiosafetySite = computed(()=> siteStore?.isBiosafetySite);

--- a/app/components/page/header/language-bar.vue
+++ b/app/components/page/header/language-bar.vue
@@ -48,7 +48,9 @@
     const limitedMenus    = ref([]);
     const otherMenus      = ref([]);
     const viewport        = useViewport();
-    const limit           = ref(siteStore.maxLangBeforeWrap);
+    // An unset maxLangBeforeWrap means "never wrap". Feeding undefined straight into the splice()
+    // calls below silently emptied the entire language menu, so fall back to "show everything".
+    const limit           = ref(siteStore.maxLangBeforeWrap ?? Number.MAX_SAFE_INTEGER);
     const query           = computed(()=> route.query);
     const isBiosafetySite = computed(()=> siteStore?.isBiosafetySite);
 

--- a/app/components/page/header/mega-menu/custom/content-type/index.vue
+++ b/app/components/page/header/mega-menu/custom/content-type/index.vue
@@ -100,7 +100,7 @@
     });
 
     const horizontalCardLimit = computed(()=> {
-        const configuredLimit = Number(siteStore?.config?.runTime?.theme?.megaMenu?.horizontalCardMax);
+        const configuredLimit = Number(siteStore.theme.megaMenu.horizontalCardMax);
 
         if(Number.isFinite(configuredLimit) && configuredLimit > 0)
             return configuredLimit;
@@ -174,7 +174,7 @@
 
         if(max) return max;
 
-        return siteStore?.config?.runTime?.theme?.megaMenu?.maxRowsPerColumn 
+        return siteStore.theme.megaMenu.maxRowsPerColumn;
     }
     function getContentTypeData(country){
         const contentTypeName = getContentType();

--- a/app/components/page/header/mega-menu/drop-down.vue
+++ b/app/components/page/header/mega-menu/drop-down.vue
@@ -60,7 +60,7 @@
         const menuStore  = useMenusStore();
         const meStore    = useMeStore();
         const isPublishedSite  = computed(()=> siteStore?.config?.published);
-        const maxColumns = computed(()=> siteStore.config?.runTime?.theme?.megaMenu?.maxColumns || 5);
+        const maxColumns = computed(()=> siteStore.theme.megaMenu.maxColumns);
         const viewport   = useViewport();
         const isMobile   = computed(() => !['lg','xl', 'xxl'].includes(viewport.breakpoint.value));
 

--- a/app/composables/schema-org.js
+++ b/app/composables/schema-org.js
@@ -1149,7 +1149,7 @@ export function useMainMenuSchemaOrg() {
             );
 
             if (validSections.length) {
-                const maxColumns = siteStore.config?.runTime?.theme?.megaMenu?.maxColumns || 5;
+                const maxColumns = siteStore.theme.megaMenu.maxColumns;
                 const rows = organizeSectionsIntoRows(validSections, maxColumns);
                 
                 const sectionSchemas = [];

--- a/app/stores/site.js
+++ b/app/stores/site.js
@@ -136,17 +136,19 @@ export const useSiteStore = defineStore('site', {
         
             return uniqueArray([  ...country , ...countries ]).filter(falsyFilter);
         },
+        // Every theme read goes through resolveTheme — see app/utils/resolve-theme.js for the
+        // precedence, per-leaf merge, hero-derive, and totality rules.
+        theme(){
+            return resolveTheme(this.config);
+        },
         primaryColor(){
-            return this.config?.theme?.color?.primary || this.config?.runTime?.theme?.color?.primary || '#009edb';
+            return this.theme.color.primary;
         },
         secondaryColor(){
-            return this.config?.theme?.color?.secondary || this.config?.runTime?.theme?.color?.secondary ;
-        },
-        theme(){
-            return this.config?.theme || this.config?.runTime?.theme || {};
+            return this.theme.color.secondary;
         },
         maxLangBeforeWrap(){
-            return this.config?.theme?.i18n?.maxLangBeforeWrap || this.config?.runTime?.theme?.i18n?.maxLangBeforeWrap  ;
+            return this.theme.i18n.maxLangBeforeWrap;
         },
         isBiosafetySite(){
             return this.baseHost.includes('bsl') || this.baseHost.includes('biosafety') || this.baseHost.includes('bch');

--- a/app/utils/resolve-theme.js
+++ b/app/utils/resolve-theme.js
@@ -1,0 +1,164 @@
+/**
+ * Canonical, crash-safe theme resolution for the head.
+ *
+ * Every theme read in the app funnels through this one function. Before it existed the same
+ * theme keys were read nine different ways across six files, each with its own precedence and
+ * its own crash path (`theme.backGround.secondary` threw when `backGround` was absent;
+ * `theme.hero.primary[0]` threw when `primary` was absent; an unset `maxLangBeforeWrap` fed
+ * `undefined` into `Array.prototype.splice` and silently emptied the language menu).
+ *
+ * ## Precedence (leg order, highest first)
+ *
+ *   1. site `config.theme`
+ *   2. `config.runTime.theme` (the network-level theme)
+ *   3. code defaults (below)
+ *
+ * NOTE: p02-01 adds the `biolandSettings.theme` leg *in front* of `config.theme`. The leg list in
+ * `resolveTheme` is the seam for that change — add the leg, change nothing else.
+ *
+ * ## Merge rule: per-leaf, not per-object
+ *
+ * Legs merge one leaf at a time, two levels deep (`theme.<group>.<leaf>`). A site that authors
+ * only `color.primary` still inherits `color.secondary`, `megaMenu.*`, and the rest from the
+ * network leg. A whole-object merge would blank out every key the site did not restate.
+ *
+ * Groups the resolver does not know about pass through untouched, so callers reading keys outside
+ * the contract (for example `color.secondaryTextOver`, `homePageWidgets.columns`,
+ * `megaMenu.forums`) keep working.
+ *
+ * ## Presence, not truthiness
+ *
+ * A leg supplies a leaf when that leaf is present (`!== undefined && !== null`), not when it is
+ * truthy. `maxRowsPerColumn: 0` means "unlimited" and must not fall through to the next leg, and
+ * an unset `maxLangBeforeWrap` must stay distinguishable from an authored `0`.
+ *
+ * ## Hero rule
+ *
+ * `hero.primary` is *derived* as `[color.primary, color.secondary]` ONLY when it is absent from
+ * every leg. An authored hero passes through untouched: live prod site `be` carries
+ * `hero.primary[1] = "#CBB279"`, which is not its `color.secondary`, so an always-derive rule
+ * would visibly change that site. A partially authored hero keeps its authored slots and has only
+ * the missing slots filled from the derived pair.
+ *
+ * ## Totality
+ *
+ * For ANY input, including `{}`, `null`, or a config with no theme at all, every contract group
+ * (`color`, `backGround`, `hero`, `megaMenu`, `i18n`, `homePageWidgets`) is an object and
+ * `hero.primary` is an array of length 2. Contract leaves are always own properties, so no
+ * optional chain and no index access on the result can throw. A leaf whose value is genuinely
+ * unset stays `undefined` rather than being invented — this function preserves today's rendered
+ * values, it does not add defaults that did not exist.
+ *
+ * ## Cloning
+ *
+ * The result never aliases the input. Arrays and plain objects reaching the caller are cloned, so
+ * a caller mutating the resolved theme cannot corrupt the shared site config.
+ *
+ * @param {object|null|undefined} config - the site config (`siteStore.config`).
+ * @returns {object} the resolved theme. Never null, never throws.
+ */
+
+/** Code defaults leg. Only keys that had a hardcoded fallback before this refactor belong here. */
+const THEME_DEFAULTS = Object.freeze({
+    color   : { primary: '#009edb' },  // was hardcoded at app/stores/site.js:140
+    megaMenu: { maxColumns: 5 }        // was hardcoded as `|| 5` at schema-org.js:1152 and drop-down.vue:63
+});
+
+/** Contract groups that must always exist on the result so callers cannot crash on a missing group. */
+const CONTRACT_GROUPS = Object.freeze(['color', 'backGround', 'hero', 'megaMenu', 'i18n', 'homePageWidgets']);
+
+/** Contract leaves, per group, that must always be own properties of the result. */
+const CONTRACT_LEAVES = Object.freeze({
+    color     : ['primary', 'secondary'],
+    backGround: ['secondary'],
+    hero      : ['primary'],
+    megaMenu  : ['maxColumns', 'maxRowsPerColumn', 'horizontalCardMax', 'forums'],
+    i18n      : ['maxLangBeforeWrap']
+});
+
+const isPresent = value => value !== undefined && value !== null;
+
+const isPlainObject = value => typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/** Deep clone of JSON-shaped data. Keeps the result free of live references into the input config. */
+const cloneValue = (value) => {
+    if (Array.isArray(value))    return value.map(cloneValue);
+    if (isPlainObject(value))    return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, cloneValue(v)]));
+
+    return value;
+};
+
+/** First leg that supplies this group leaf wins. Presence, not truthiness. */
+const resolveLeaf = (legs, group, leaf) => {
+    for (const leg of legs) {
+        const value = isPlainObject(leg?.[group]) ? leg[group][leaf] : undefined;
+
+        if (isPresent(value)) return cloneValue(value);
+    }
+
+    return undefined;
+};
+
+/** Union of the group names any leg defines, plus every contract group. */
+const collectGroups = legs => [...new Set([...CONTRACT_GROUPS, ...legs.flatMap(leg => Object.keys(leg || {}))])];
+
+/** Union of the leaf names any leg defines under `group`, plus that group's contract leaves. */
+const collectLeaves = (legs, group) => [...new Set([
+    ...(CONTRACT_LEAVES[group] || []),
+    ...legs.flatMap(leg => (isPlainObject(leg?.[group]) ? Object.keys(leg[group]) : []))
+])];
+
+/**
+ * A non-group key (a scalar or array sitting directly on the theme, not a nested object).
+ * Resolved as a single leaf so unknown shapes still pass through.
+ */
+const resolveScalarGroup = (legs, group) => {
+    for (const leg of legs) {
+        const value = leg?.[group];
+
+        if (isPresent(value) && !isPlainObject(value)) return cloneValue(value);
+    }
+
+    return undefined;
+};
+
+/**
+ * Derive-when-absent hero. Fills only the slots no leg authored.
+ * @param {Array|undefined} authored - the merged `hero.primary`, if any leg supplied one.
+ * @param {object} color - the resolved color group.
+ */
+const resolveHeroPrimary = (authored, color) => {
+    const derived = [color.primary, color.secondary];
+    const source  = Array.isArray(authored) ? authored : [];
+
+    return [0, 1].map(i => (isPresent(source[i]) ? source[i] : derived[i]));
+};
+
+export function resolveTheme(config) {
+    const legs = [config?.theme, config?.runTime?.theme, THEME_DEFAULTS].filter(isPlainObject);
+
+    const resolved = {};
+
+    for (const group of collectGroups(legs)) {
+        const leaves = collectLeaves(legs, group);
+
+        // A key no leg defines as an object (e.g. a stray scalar on the theme) passes through as-is.
+        if (!leaves.length) {
+            const scalar = resolveScalarGroup(legs, group);
+
+            if (isPresent(scalar)) resolved[group] = scalar;
+            else if (CONTRACT_GROUPS.includes(group)) resolved[group] = {};
+
+            continue;
+        }
+
+        resolved[group] = Object.fromEntries(leaves.map(leaf => [leaf, resolveLeaf(legs, group, leaf)]));
+    }
+
+    // Hero is the one group with a derivation rule rather than a plain default.
+    resolved.hero.primary = resolveHeroPrimary(resolved.hero.primary, resolved.color);
+
+    return resolved;
+}
+
+export default resolveTheme;

--- a/app/utils/resolve-theme.js
+++ b/app/utils/resolve-theme.js
@@ -26,11 +26,29 @@
  * the contract (for example `color.secondaryTextOver`, `homePageWidgets.columns`,
  * `megaMenu.forums`) keep working.
  *
- * ## Presence, not truthiness
+ * ## Presence, not truthiness — with three validated leaves
  *
  * A leg supplies a leaf when that leaf is present (`!== undefined && !== null`), not when it is
  * truthy. `maxRowsPerColumn: 0` means "unlimited" and must not fall through to the next leg, and
  * an unset `maxLangBeforeWrap` must stay distinguishable from an authored `0`.
+ *
+ * Three leaves are the exception, because their pre-refactor reads used `||` AND a falsy-but-present
+ * value breaks the render rather than meaning something. See `LEAF_VALIDATORS`. For those, a leg
+ * supplies the leaf only when the value is also *usable*; otherwise it falls through to the next leg
+ * exactly as the old `||` chain did. Every other leaf keeps the plain presence rule, including
+ * `backGround.secondary`, whose old read had no `||` at all — `''` was preserved before this
+ * refactor and is preserved now.
+ *
+ * ## `i18n.maxLangBeforeWrap` is deliberately left unset
+ *
+ * The resolver returns `undefined` when no leg authors it. It does NOT invent a "never wrap"
+ * sentinel, because there was no such value before this refactor — the old code fed `undefined`
+ * straight into `Array.prototype.splice`, whose return value is the *removed* elements, so an unset
+ * `maxLangBeforeWrap` really did render an empty language bar. That was a bug, not a value worth
+ * preserving, and inventing a replacement default here would violate the totality rule below.
+ * **Contract: the caller owns the unset behaviour.** `language-bar.vue` supplies
+ * `?? Number.MAX_SAFE_INTEGER` ("show everything"); any future consumer must make the same choice
+ * explicitly rather than passing `undefined` into an arithmetic or slicing API.
  *
  * ## Hero rule
  *
@@ -78,6 +96,42 @@ const CONTRACT_LEAVES = Object.freeze({
 
 const isPresent = value => value !== undefined && value !== null;
 
+/** A colour a browser can actually apply. `''` interpolated into a style declaration voids it. */
+const isUsableColor = value => typeof value === 'string' && value.trim() !== '';
+
+/** A column count that yields at least one column. `0` collapses the mega-menu grid to nothing. */
+const isUsableColumnCount = value => Number.isFinite(Number(value)) && Number(value) >= 1;
+
+/**
+ * Per-leaf validators — the deliberate exceptions to the presence rule.
+ *
+ * A leaf earns a validator only when BOTH hold: its pre-refactor read used `||` (so falsy values
+ * already fell through and no live site can be relying on one), and a falsy-but-present value
+ * produces a broken render rather than a meaningful setting. That is exactly three leaves:
+ *
+ * - `color.primary`   — was `|| '#009edb'` at site.js:140. `''` voids every `solid ${primary}`
+ *                       border and `background: ${primary}` declaration that consumes it.
+ * - `color.secondary` — was `||` (no final default) at site.js:143. Same failure mode, and
+ *                       `hero.primary` derives its second slot from it.
+ * - `megaMenu.maxColumns` — was `|| 5` at schema-org.js:1152 and drop-down.vue:63. `0` makes
+ *                       `organizeSectionsIntoRows` collapse every section into one unbounded row
+ *                       (`Math.min(span, 0) === 0`, so the wrap branch never fires).
+ *
+ * Explicitly NOT validated, with reasons:
+ * - `backGround.secondary` — its old read had no `||`, so `''` was already passed through and
+ *   rendered. `backGround.primary: ''` demonstrably occurs in the live network theme; rejecting it
+ *   would be the regression, not the fix.
+ * - `megaMenu.maxRowsPerColumn` / `horizontalCardMax` / `forums` — no `||` in the old reads, and
+ *   `0` is a meaningful value ("unlimited") that must not fall through.
+ * - `i18n.maxLangBeforeWrap` — `0` and `''` both mean "wrap immediately"; the language bar degrades
+ *   gracefully (every language moves into the overflow dropdown) rather than breaking. See the
+ *   contract note in the header comment for the *unset* case.
+ */
+const LEAF_VALIDATORS = Object.freeze({
+    color   : { primary: isUsableColor, secondary: isUsableColor },
+    megaMenu: { maxColumns: isUsableColumnCount }
+});
+
 const isPlainObject = value => typeof value === 'object' && value !== null && !Array.isArray(value);
 
 /** Deep clone of JSON-shaped data. Keeps the result free of live references into the input config. */
@@ -88,12 +142,20 @@ const cloneValue = (value) => {
     return value;
 };
 
-/** First leg that supplies this group leaf wins. Presence, not truthiness. */
+/**
+ * First leg that supplies this group leaf wins. Presence, not truthiness — except for the leaves in
+ * `LEAF_VALIDATORS`, which must also be usable or they fall through to the next leg.
+ */
 const resolveLeaf = (legs, group, leaf) => {
+    const isUsable = LEAF_VALIDATORS[group]?.[leaf];
+
     for (const leg of legs) {
         const value = isPlainObject(leg?.[group]) ? leg[group][leaf] : undefined;
 
-        if (isPresent(value)) return cloneValue(value);
+        if (!isPresent(value))            continue;
+        if (isUsable && !isUsable(value)) continue;
+
+        return cloneValue(value);
     }
 
     return undefined;
@@ -109,14 +171,17 @@ const collectLeaves = (legs, group) => [...new Set([
 ])];
 
 /**
- * A non-group key (a scalar or array sitting directly on the theme, not a nested object).
- * Resolved as a single leaf so unknown shapes still pass through.
+ * A theme key with no leaves to merge — a scalar or array sitting directly on the theme, or an
+ * object every leg left empty. Resolved whole so unknown shapes still pass through: the old
+ * whole-object getter kept `theme.foo = {}`, and a caller doing `theme.foo.bar` without an optional
+ * chain must not start throwing. Any plain object reaching here is empty by construction, since a
+ * non-empty one would have produced leaves.
  */
-const resolveScalarGroup = (legs, group) => {
+const resolveOpaqueGroup = (legs, group) => {
     for (const leg of legs) {
         const value = leg?.[group];
 
-        if (isPresent(value) && !isPlainObject(value)) return cloneValue(value);
+        if (isPresent(value)) return cloneValue(value);
     }
 
     return undefined;
@@ -142,11 +207,12 @@ export function resolveTheme(config) {
     for (const group of collectGroups(legs)) {
         const leaves = collectLeaves(legs, group);
 
-        // A key no leg defines as an object (e.g. a stray scalar on the theme) passes through as-is.
+        // A key with nothing to merge (a stray scalar, or an object every leg left empty) passes
+        // through as-is rather than being dropped off the result.
         if (!leaves.length) {
-            const scalar = resolveScalarGroup(legs, group);
+            const opaque = resolveOpaqueGroup(legs, group);
 
-            if (isPresent(scalar)) resolved[group] = scalar;
+            if (isPresent(opaque)) resolved[group] = opaque;
             else if (CONTRACT_GROUPS.includes(group)) resolved[group] = {};
 
             continue;
@@ -160,5 +226,3 @@ export function resolveTheme(config) {
 
     return resolved;
 }
-
-export default resolveTheme;

--- a/tests/unit/app/utils/resolve-theme.test.ts
+++ b/tests/unit/app/utils/resolve-theme.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect } from 'vitest'
+import { resolveTheme } from '../../../../app/utils/resolve-theme'
+
+/**
+ * Value-preservation suite for the canonical theme resolver.
+ *
+ * The nine expressions below are verbatim transcriptions of the pre-refactor reads. Every
+ * "preserves today's value" assertion compares the resolver against one of them, so the suite
+ * fails the moment the refactor changes a rendered value.
+ */
+const before = {
+    // app/stores/site.js:140
+    primaryColor      : (c: any) => c?.theme?.color?.primary || c?.runTime?.theme?.color?.primary || '#009edb',
+    // app/stores/site.js:143
+    secondaryColor    : (c: any) => c?.theme?.color?.secondary || c?.runTime?.theme?.color?.secondary,
+    // app/stores/site.js:146
+    theme             : (c: any) => c?.theme || c?.runTime?.theme || {},
+    // app/stores/site.js:149
+    maxLangBeforeWrap : (c: any) => c?.theme?.i18n?.maxLangBeforeWrap || c?.runTime?.theme?.i18n?.maxLangBeforeWrap,
+    // app/composables/schema-org.js:1152 and drop-down.vue:63
+    maxColumns        : (c: any) => c?.runTime?.theme?.megaMenu?.maxColumns || 5,
+    // content-type/index.vue:103
+    horizontalCardMax : (c: any) => c?.runTime?.theme?.megaMenu?.horizontalCardMax,
+    // content-type/index.vue:177
+    maxRowsPerColumn  : (c: any) => c?.runTime?.theme?.megaMenu?.maxRowsPerColumn,
+    // language-bar.vue:59
+    backGround        : (c: any) => (c?.theme || c?.runTime?.theme || {})?.backGround?.secondary,
+    // hero-image.vue:112,117
+    heroPrimary       : (c: any) => (c?.theme || c?.runTime?.theme || {})?.hero?.primary
+}
+
+/** The live prod network theme (dmsm prod/bl2 network `config.theme`), used as the runTime leg. */
+const networkTheme = {
+    homePageWidgets: { news: true, columns: [['panorama', 'gbif'], ['implementation'], ['forums']] },
+    color          : { primary: '#009edb', primaryTextOver: '#ffffff', secondary: '#16c56e', secondaryTextOver: '#ffffff' },
+    hero           : { primary: ['#009edb', '#16c56e'] },
+    text           : { primary: '#222222', secondary: '#4D4D4D' },
+    backGround     : { primary: '', secondary: '#F2F2F2', tertiary: '#4D4D4D' },
+    megaMenu       : { forums: true, maxColumns: 5, maxRowsPerColumn: 6, horizontalCardMax: 3, horizontalCardWrap: false },
+    i18n           : { maxLangBeforeWrap: 6 }
+}
+
+/** Live prod site `be` — the fleet's authored-hero case (hero.primary[1] is NOT color.secondary). */
+const beTheme = {
+    color          : { primary: '#7b6f82', primaryTextOver: '#ffffff', secondary: '#889262', secondaryTextOver: '#000000' },
+    hero           : { primary: ['#7b6f82', '#CBB279'] },
+    text           : { primary: '#222222', secondary: '#4D4D4D' },
+    backGround     : { primary: '', secondary: '#F2F2F2', tertiary: '#4D4D4D' },
+    megaMenu       : { maxColumns: 5, maxRowsPerColumn: 6, horizontalCardMax: 3, horizontalCardWrap: false, forums: true },
+    i18n           : { maxLangBeforeWrap: 6 },
+    homePageWidgets: { news: true, columns: [['panorama', 'gbif'], ['implementation'], ['forums']] }
+}
+
+const withRunTime = (theme: any, site?: any) => ({ ...(site ? { theme: site } : {}), runTime: { theme } })
+
+describe('resolveTheme', () => {
+
+    describe('totality — no input can produce a crash path', () => {
+        const empties = [
+            ['undefined', undefined],
+            ['null', null],
+            ['{}', {}],
+            ['config with no theme at all', { siteCode: 'x', runTime: {} }],
+            ['config.theme null', { theme: null, runTime: { theme: null } }]
+        ] as const
+
+        for (const [label, config] of empties) {
+            it(`yields every contract group for ${label}`, () => {
+                const theme = resolveTheme(config as any)
+
+                for (const group of ['color', 'backGround', 'hero', 'megaMenu', 'i18n', 'homePageWidgets'])
+                    expect(theme[group], group).toBeTypeOf('object')
+
+                // The three former crash sites, exercised directly.
+                expect(() => theme.backGround.secondary).not.toThrow()   // language-bar.vue:59
+                expect(() => theme.hero.primary[0]).not.toThrow()        // hero-image.vue:112
+                expect(() => theme.hero.primary[1]).not.toThrow()        // hero-image.vue:117
+            })
+
+            it(`declares every contract leaf as an own property for ${label}`, () => {
+                const theme = resolveTheme(config as any)
+
+                expect(Object.keys(theme.color)).toEqual(expect.arrayContaining(['primary', 'secondary']))
+                expect(Object.keys(theme.backGround)).toContain('secondary')
+                expect(Object.keys(theme.i18n)).toContain('maxLangBeforeWrap')
+                expect(Object.keys(theme.megaMenu)).toEqual(
+                    expect.arrayContaining(['maxColumns', 'maxRowsPerColumn', 'horizontalCardMax', 'forums'])
+                )
+            })
+        }
+
+        it('hero.primary is always a two-slot array', () => {
+            for (const config of [undefined, null, {}, { theme: {} }, { theme: { hero: {} } }, { theme: { hero: { primary: [] } } }])
+                expect(resolveTheme(config as any).hero.primary).toHaveLength(2)
+        })
+
+        it('applies the code defaults leg when nothing else supplies the leaf', () => {
+            const theme = resolveTheme({} as any)
+
+            expect(theme.color.primary).toBe('#009edb')   // was hardcoded at site.js:140
+            expect(theme.megaMenu.maxColumns).toBe(5)     // was hardcoded as `|| 5`
+        })
+    })
+
+    describe('precedence — site theme beats runTime beats defaults', () => {
+        it('prefers the site leg over the runTime leg', () => {
+            const theme = resolveTheme(withRunTime(networkTheme, beTheme) as any)
+
+            expect(theme.color.primary).toBe('#7b6f82')
+            expect(theme.color.secondary).toBe('#889262')
+        })
+
+        it('falls through to the runTime leg for a theme-less site', () => {
+            const theme = resolveTheme(withRunTime(networkTheme) as any)
+
+            expect(theme.color.primary).toBe('#009edb')
+            expect(theme.color.secondary).toBe('#16c56e')
+            expect(theme.i18n.maxLangBeforeWrap).toBe(6)
+        })
+
+        it('falls through to the defaults leg when neither theme supplies the leaf', () => {
+            expect(resolveTheme({ theme: {}, runTime: { theme: {} } } as any).color.primary).toBe('#009edb')
+        })
+    })
+
+    describe('per-leaf merge, not per-object', () => {
+        it('keeps runTime siblings when the site authors only one leaf of a group', () => {
+            const theme = resolveTheme(withRunTime(networkTheme, { color: { primary: '#ff0000' } }) as any)
+
+            expect(theme.color.primary).toBe('#ff0000')             // authored
+            expect(theme.color.secondary).toBe('#16c56e')           // inherited
+            expect(theme.color.secondaryTextOver).toBe('#ffffff')   // non-contract key inherited too
+            expect(theme.megaMenu.maxRowsPerColumn).toBe(6)         // whole group inherited
+        })
+
+        it('closes the whole-object gap that made language-bar.vue:59 throw', () => {
+            // Pre-refactor, `config.theme || runTime.theme` returned the site object wholesale, so a
+            // site authoring only `color` had NO backGround group at all and `theme.backGround.secondary`
+            // threw. This is the one intended divergence from the old reads; the fleet-parity run
+            // records how many live sites are affected (see prod-theme-inventory-fe.md).
+            const config = withRunTime(networkTheme, { color: { primary: '#ff0000' } }) as any
+
+            expect(before.theme(config).backGround).toBeUndefined()
+            expect(() => before.theme(config).backGround.secondary).toThrow()
+            expect(resolveTheme(config).backGround.secondary).toBe('#F2F2F2')
+        })
+
+        it('passes non-contract groups through untouched', () => {
+            const theme = resolveTheme(withRunTime(networkTheme) as any)
+
+            expect(theme.text).toEqual({ primary: '#222222', secondary: '#4D4D4D' })
+            expect(theme.homePageWidgets.columns).toEqual(networkTheme.homePageWidgets.columns)
+            expect(theme.megaMenu.forums).toBe(true)
+        })
+    })
+
+    describe('hero — derived only when absent from every source', () => {
+        it('leaves an authored hero untouched (live prod site `be`)', () => {
+            const theme = resolveTheme(withRunTime(networkTheme, beTheme) as any)
+
+            expect(theme.hero.primary).toEqual(['#7b6f82', '#CBB279'])
+            // The delta that makes the rule necessary: slot 1 is NOT the derived secondary.
+            expect(theme.hero.primary[1]).not.toBe(theme.color.secondary)
+        })
+
+        it('derives [color.primary, color.secondary] only when no leg authors a hero', () => {
+            const noHero = { ...networkTheme, hero: undefined }
+            const theme  = resolveTheme(withRunTime(noHero, { color: { primary: '#111111', secondary: '#222222' } }) as any)
+
+            expect(theme.hero.primary).toEqual(['#111111', '#222222'])
+        })
+
+        it('prefers an authored hero on the runTime leg over deriving', () => {
+            const theme = resolveTheme(withRunTime(networkTheme, { color: { primary: '#111111' } }) as any)
+
+            expect(theme.hero.primary).toEqual(['#009edb', '#16c56e'])
+        })
+
+        it('fills only the missing slot of a partially authored hero', () => {
+            const theme = resolveTheme({ theme: { color: { primary: '#111111', secondary: '#222222' }, hero: { primary: ['#abcdef'] } } } as any)
+
+            expect(theme.hero.primary).toEqual(['#abcdef', '#222222'])
+        })
+    })
+
+    describe('presence, not truthiness', () => {
+        it('keeps an authored maxRowsPerColumn of 0 instead of falling through', () => {
+            const theme = resolveTheme(withRunTime(networkTheme, { megaMenu: { maxRowsPerColumn: 0 } }) as any)
+
+            expect(theme.megaMenu.maxRowsPerColumn).toBe(0)
+            expect(theme.megaMenu.maxRowsPerColumn).not.toBe(6)
+        })
+
+        it('keeps an authored maxColumns of 0 instead of falling back to the default 5', () => {
+            expect(resolveTheme({ theme: { megaMenu: { maxColumns: 0 } } } as any).megaMenu.maxColumns).toBe(0)
+        })
+
+        it('distinguishes an unset maxLangBeforeWrap from an authored 0', () => {
+            expect(resolveTheme({ theme: { i18n: {} } } as any).i18n.maxLangBeforeWrap).toBeUndefined()
+            expect(resolveTheme({ theme: { i18n: { maxLangBeforeWrap: 0 } } } as any).i18n.maxLangBeforeWrap).toBe(0)
+        })
+
+        it('keeps an authored empty-string backGround.secondary rather than inheriting', () => {
+            const theme = resolveTheme(withRunTime(networkTheme, { backGround: { secondary: '' } }) as any)
+
+            expect(theme.backGround.secondary).toBe('')
+        })
+    })
+
+    describe('tolerates malformed theme data', () => {
+        it('passes a scalar sitting directly on the theme through untouched', () => {
+            const theme = resolveTheme({ theme: { version: 3, tags: ['a', 'b'] } } as any)
+
+            expect(theme.version).toBe(3)
+            expect(theme.tags).toEqual(['a', 'b'])
+        })
+
+        it('clones a top-level array rather than aliasing it', () => {
+            const tags   = ['a']
+            const theme  = resolveTheme({ theme: { tags } } as any)
+
+            theme.tags.push('mutated')
+
+            expect(tags).toEqual(['a'])
+        })
+
+        it('replaces a scalar-valued contract group with an empty object', () => {
+            const theme = resolveTheme({ theme: { homePageWidgets: null }, runTime: { theme: {} } } as any)
+
+            expect(theme.homePageWidgets).toEqual({})
+        })
+
+        it('ignores a non-object theme leg entirely', () => {
+            const theme = resolveTheme({ theme: 'nonsense', runTime: { theme: networkTheme } } as any)
+
+            expect(theme.color.primary).toBe('#009edb')
+            expect(theme.i18n.maxLangBeforeWrap).toBe(6)
+        })
+
+        it('survives a scalar hero', () => {
+            const theme = resolveTheme({ theme: { color: { primary: '#111111', secondary: '#222222' }, hero: 'nope' } } as any)
+
+            expect(theme.hero.primary).toEqual(['#111111', '#222222'])
+        })
+    })
+
+    describe('the language-bar splice path', () => {
+        const languages = ['en', 'fr', 'es', 'ru', 'ar', 'zh', 'de', 'pt']
+
+        /** Verbatim transcription of language-bar.vue's split, given a resolved limit. */
+        const split = (limit: number) => ({
+            limited: [...languages].splice(0, limit),
+            other  : languages.length > limit ? [...languages].splice(limit, languages.length - limit) : []
+        })
+
+        it('reproduces today`s split when maxLangBeforeWrap is authored', () => {
+            const limit = resolveTheme(withRunTime(networkTheme) as any).i18n.maxLangBeforeWrap
+
+            expect(limit).toBe(before.maxLangBeforeWrap(withRunTime(networkTheme)))
+            expect(split(limit)).toEqual({ limited: ['en', 'fr', 'es', 'ru', 'ar', 'zh'], other: ['de', 'pt'] })
+        })
+
+        it('shows every language instead of emptying the menu when the limit is unset', () => {
+            const raw   = resolveTheme({} as any).i18n.maxLangBeforeWrap
+            const limit = raw ?? Number.MAX_SAFE_INTEGER
+
+            expect(raw).toBeUndefined()
+            // The defect: the pre-refactor value fed undefined into splice and emptied the menu.
+            expect([...languages].splice(0, raw as any)).toEqual([])
+            expect(split(limit)).toEqual({ limited: languages, other: [] })
+        })
+    })
+
+    describe('does not alias the input config', () => {
+        it('clones arrays so a caller cannot mutate the shared config', () => {
+            const config = withRunTime(networkTheme, beTheme) as any
+            const theme  = resolveTheme(config)
+
+            theme.hero.primary[0] = '#mutated'
+            theme.homePageWidgets.columns[0][0] = '#mutated'
+
+            expect(beTheme.hero.primary[0]).toBe('#7b6f82')
+            expect(beTheme.homePageWidgets.columns[0][0]).toBe('panorama')
+        })
+
+        it('returns a fresh object on every call', () => {
+            const config = withRunTime(networkTheme) as any
+
+            expect(resolveTheme(config)).not.toBe(resolveTheme(config))
+            expect(resolveTheme(config)).toEqual(resolveTheme(config))
+        })
+    })
+
+    describe('value preservation against the nine pre-refactor expressions', () => {
+        const fixtures: Array<[string, any]> = [
+            ['authored site theme (be)',    withRunTime(networkTheme, beTheme)],
+            ['theme-less site (seed)',      withRunTime(networkTheme)],
+            ['partial site theme',          withRunTime(networkTheme, { color: { primary: '#ff0000' } })],
+            ['bare site config',            { runTime: {} }],
+            ['empty config',                {}]
+        ]
+
+        for (const [label, config] of fixtures) {
+            it(`matches every pre-refactor read for ${label}`, () => {
+                const theme = resolveTheme(config)
+
+                expect(theme.color.primary).toBe(before.primaryColor(config))
+                expect(theme.color.secondary).toBe(before.secondaryColor(config))
+                expect(theme.i18n.maxLangBeforeWrap).toBe(before.maxLangBeforeWrap(config))
+                expect(theme.megaMenu.maxColumns).toBe(before.maxColumns(config))
+                expect(theme.megaMenu.horizontalCardMax).toBe(before.horizontalCardMax(config))
+                expect(theme.megaMenu.maxRowsPerColumn).toBe(before.maxRowsPerColumn(config))
+
+                // backGround and hero came off the whole-object `theme` getter, which dropped every
+                // group the site leg did not restate. Where that getter returned a value, the
+                // resolver returns the same one; where it returned undefined, the per-leaf merge
+                // now supplies the runTime value (see the dedicated divergence test below).
+                const wholeObject = before.backGround(config)
+
+                if (wholeObject !== undefined) expect(theme.backGround.secondary).toBe(wholeObject)
+
+                // "Absent from EVERY source" — the whole-object read above only sees one leg.
+                const authoredHero = config?.theme?.hero?.primary || config?.runTime?.theme?.hero?.primary
+
+                if (authoredHero) expect(theme.hero.primary).toEqual(authoredHero)
+                else expect(theme.hero.primary).toEqual([theme.color.primary, theme.color.secondary])
+            })
+        }
+    })
+})

--- a/tests/unit/app/utils/resolve-theme.test.ts
+++ b/tests/unit/app/utils/resolve-theme.test.ts
@@ -191,8 +191,8 @@ describe('resolveTheme', () => {
             expect(theme.megaMenu.maxRowsPerColumn).not.toBe(6)
         })
 
-        it('keeps an authored maxColumns of 0 instead of falling back to the default 5', () => {
-            expect(resolveTheme({ theme: { megaMenu: { maxColumns: 0 } } } as any).megaMenu.maxColumns).toBe(0)
+        it('distinguishes an unset maxRowsPerColumn from an authored 0', () => {
+            expect(resolveTheme({ theme: { megaMenu: {} } } as any).megaMenu.maxRowsPerColumn).toBeUndefined()
         })
 
         it('distinguishes an unset maxLangBeforeWrap from an authored 0', () => {
@@ -207,12 +207,83 @@ describe('resolveTheme', () => {
         })
     })
 
+    // The three leaves whose old reads used `||` AND whose falsy values break the render.
+    // Contract: a falsy-but-present value falls through to the next leg, exactly as `||` did.
+    describe('validated leaves', () => {
+        describe('megaMenu.maxColumns', () => {
+            it('never resolves to a value that would collapse the grid', () => {
+                for (const authored of [0, '', null, -3]) {
+                    const theme = resolveTheme({ theme: { megaMenu: { maxColumns: authored } } } as any)
+
+                    expect(Number(theme.megaMenu.maxColumns)).toBeGreaterThanOrEqual(1)
+                }
+            })
+
+            it('falls through an unusable site value to the network leg, not straight to the default', () => {
+                const theme = resolveTheme(withRunTime({ megaMenu: { maxColumns: 4 } }, { megaMenu: { maxColumns: 0 } }) as any)
+
+                expect(theme.megaMenu.maxColumns).toBe(4)
+            })
+
+            it('falls back to the code default of 5 when no leg supplies a usable value', () => {
+                expect(resolveTheme({ theme: { megaMenu: { maxColumns: 0 } } } as any).megaMenu.maxColumns).toBe(5)
+            })
+
+            it('keeps a usable authored value, including a numeric string', () => {
+                expect(resolveTheme({ theme: { megaMenu: { maxColumns: 3 } } } as any).megaMenu.maxColumns).toBe(3)
+                expect(resolveTheme({ theme: { megaMenu: { maxColumns: '4' } } } as any).megaMenu.maxColumns).toBe('4')
+            })
+        })
+
+        describe('color.primary / color.secondary', () => {
+            it('falls through an empty-string primary to the network leg', () => {
+                const theme = resolveTheme(withRunTime({ color: { primary: '#123456' } }, { color: { primary: '' } }) as any)
+
+                expect(theme.color.primary).toBe('#123456')
+            })
+
+            it('falls back to the code default when no leg supplies a usable primary', () => {
+                expect(resolveTheme({ theme: { color: { primary: '   ' } } } as any).color.primary).toBe('#009edb')
+            })
+
+            it('falls through an empty-string secondary to the network leg', () => {
+                const theme = resolveTheme(withRunTime({ color: { secondary: '#abcdef' } }, { color: { secondary: '' } }) as any)
+
+                expect(theme.color.secondary).toBe('#abcdef')
+            })
+
+            it('never derives a hero slot from an unusable colour', () => {
+                const theme = resolveTheme({ theme: { color: { primary: '', secondary: '' } } } as any)
+
+                expect(theme.hero.primary[0]).toBe('#009edb')
+                expect(theme.hero.primary).toHaveLength(2)
+            })
+        })
+    })
+
     describe('tolerates malformed theme data', () => {
         it('passes a scalar sitting directly on the theme through untouched', () => {
             const theme = resolveTheme({ theme: { version: 3, tags: ['a', 'b'] } } as any)
 
             expect(theme.version).toBe(3)
             expect(theme.tags).toEqual(['a', 'b'])
+        })
+
+        it('keeps a non-contract group authored as an empty object rather than dropping it', () => {
+            // The old whole-object getter kept `theme.foo = {}`, so `theme.foo.bar` must not throw.
+            const theme = resolveTheme({ theme: { foo: {} } } as any)
+
+            expect(theme.foo).toEqual({})
+            expect(() => theme.foo.bar).not.toThrow()
+        })
+
+        it('clones an empty non-contract group rather than aliasing it', () => {
+            const foo   = {}
+            const theme = resolveTheme({ theme: { foo } } as any)
+
+            theme.foo.mutated = true
+
+            expect(foo).toEqual({})
         })
 
         it('clones a top-level array rather than aliasing it', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
-      include: ['server/utils/**/*.ts']
+      include: ['server/utils/**/*.ts', 'app/utils/resolve-theme.js']
     }
   },
   resolve: {


### PR DESCRIPTION
### Problem

Head read each site's theme from nine scattered expressions. Four skipped `config.theme` entirely, so a site authoring its own mega-menu bounds was ignored. Three threw on a missing key. No single place said what a theme is.

### Resolution

One total, crash-safe `resolveTheme(config)` behind every read. Same rendered values, no throw path left. It also becomes the seam the authored-theme leg plugs into next.

### Evidence

Checked against the live fleet: 4,884 comparisons, **0 unexplained deltas**. Tests went 326 to 376, all 50 new resolver tests passing, failure set unchanged. Resolver coverage 98% statements, 95% branches. Code review Approve with comments, security Approve, 2 cycles.

<details><summary>Full details</summary>

**Jira:** [BL-881](https://scbd.atlassian.net/browse/BL-881) (epic [BL-880](https://scbd.atlassian.net/browse/BL-880))

## Precedence

`site config.theme` > `runTime.theme` > code defaults, merged per leaf. The authored `biolandSettings.theme` leg is deliberately **not** here — it is [BL-885](https://scbd.atlassian.net/browse/BL-885), which branches from this commit. The JSDoc names its insertion point.

## Fleet parity

The resolver's output was diffed against the old expressions across all four network documents.

| Measure | Result |
| --- | --- |
| Site records compared | 444 |
| Leaf comparisons | 4,884 |
| Unexplained deltas | **0** |
| Sites with an authored hero | `be`, `e2e`, `han`, `rjh` — 8 records |
| Records lacking an authored hero | 0 |

The 444 and 4,884 figures count records and comparisons **processed**, not distinct sites. Do not quote them as a site count.

The authored-hero finding matters: those four sites carry `["#7b6f82", "#CBB279"]` where a naive always-derive rule would produce `["#7b6f82", "#889262"]`. So `hero` derives only when absent from every source, and an authored hero passes through untouched.

Because no record lacks an authored hero, the derive branch never fires in production. It is covered by tests only, which is why the reviewer examined it specifically.

## Three declared divergences

Every one is fleet-verified at zero live impact and recorded in the evidence artefact.

1. **The per-leaf merge closes a whole-object gap** that made `language-bar.vue:59` throw. A test proves the old expression throws where the new one returns a value.
2. **Four `runTime`-only reads gain the `config.theme` leg.** A site authoring its own `megaMenu` was previously ignored. That is a correctness fix.
3. **Falsy handling is now decided per leaf**, added in cycle 2. See below.

## Falsy values, decided per leaf

The first cut applied one presence rule everywhere, which silently changed `megaMenu.maxColumns` from truthiness to presence. The old read was `|| 5`, so an authored `0` used to yield `5`; under a blanket presence rule it would pass through and collapse the mega-menu layout. No site does that today, but [BL-885](https://scbd.atlassian.net/browse/BL-885) is about to let editors author these values, so it was worth fixing rather than documenting.

`LEAF_VALIDATORS` now makes a present-but-unusable value fall through to the next leg, exactly as the old `||` chain did.

| Leaf | Rule | Why |
| --- | --- | --- |
| `color.primary` | validate | old read had `\|\|`; `''` voids `solid ${primary}` |
| `color.secondary` | validate | old read had `\|\|`; also feeds the derived hero |
| `megaMenu.maxColumns` | validate, coerce to >= 1 | old read had `\|\| 5`; `0` collapses row organisation |
| `backGround.secondary` | presence | old read had **no** `\|\|`; the live network theme carries `backGround.primary: ''`, so rejecting `''` would itself be the regression |
| `maxRowsPerColumn`, `horizontalCardMax`, `forums` | presence | no `\|\|` in the old reads; `0` means unlimited |
| `i18n.maxLangBeforeWrap` | presence | `0` and `''` mean wrap immediately, which degrades to the overflow dropdown |

## LOC Breakdown

| Category | LOC | Review est. |
| --- | --- | --- |
| Implementation | 64 | 2.2 min |
| Tests | 401 | 8.2 min |
| Config tweaks | 1 | — |
| **Total impl** | 64 | **11 min** |

> **Review estimate:** ~11 min - [methodology](https://gist.github.com/randyhoulahan/d9b22ccebaa37370a57d53f406e012da).

## Verification

| Check | Result |
| --- | --- |
| `yarn test:run` base | 326 = 17 failed / 309 passed |
| `yarn test:run` after | 376 = 17 failed / 359 passed |
| Failure set | byte-identical, verified by diffing sorted FAIL lines |
| Resolver coverage | 98.36% stmts, 94.87% branch, 100% lines |
| Surviving scattered reads | none — `grep` shows no `runTime.theme` or `config.theme` read outside the resolver |
| Independence vs `bsl-2026-04` | pass |
| lint / typecheck | N/A — no such script in this repo |

The 17 failures are pre-existing on the base branch: `tests/unit/server/middleware/cache-control.test.js` fails with `CACHE_TTL is not defined`, a missing Nuxt auto-import in the plain-node Vitest env. Neither that test nor `server/middleware/cache-control.js` is in scope here.

`vitest.config.ts` gains one line. Its coverage `include` was scoped to `server/utils/**/*.ts`, so the resolver's coverage was otherwise unmeasurable. There is no `thresholds` key in the config, so this changes what the report prints and cannot fail CI.

## Review

Two cycles.

- **Cycle 1, code review** — Approve with comments. The reviewer read every call site against `git show origin/bsl-2026-04:<file>`, confirmed value preservation for all present values, judged both declared divergences genuine rather than smuggled scope, verified totality across `{}`, `null`, `undefined`, and scalar inputs, and confirmed the test suite pins the old contract rather than asserting the implementation back at itself. One Major, three Minors, one Nit.
- **Cycle 1, security** — Approve, no findings. Traced theme values through to the CSS and JSON-LD sinks and found no widened injection surface. Confirmed the `splice` bound cannot drive unbounded allocation, and that no dependency or workflow file changed.
- **Cycle 2** — all five addressed in [f2e8445](https://github.com/scbd/bioland-head/commit/f2e8445630f80f4d757acb76ba445f21c364e9f2). Same nine files, no scope creep. The Major became the per-leaf validator table above. A non-contract group authored as `{}` is no longer dropped. The unset-`maxLangBeforeWrap` behaviour is now declared in the JSDoc as the caller's. The fleet-parity harness is pasted verbatim into the evidence artefact so the 4,884-comparison claim is reproducible, along with a note on how the comparator treated falsy leaves.

One correction worth recording: an earlier reading held that `splice(0, undefined)` was harmless because it removes zero elements. It removes zero elements, but the code assigns splice's **return value**, so `limitedMenus` became `[]` and the language bar rendered nothing. Fleet impact is zero because every site authors `maxLangBeforeWrap`.

## Context

First of five PRs from the `themeing-front-end` plan, and the base for [BL-885](https://scbd.atlassian.net/browse/BL-885). The contract it implements is recorded in ADR 0012, [BL-882](https://scbd.atlassian.net/browse/BL-882).

</details>


[BL-881]: https://scbd.atlassian.net/browse/BL-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-880]: https://scbd.atlassian.net/browse/BL-880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-885]: https://scbd.atlassian.net/browse/BL-885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ