### PR TITLE
feat: BL-885 activate biolandSettings.theme as the first precedence leg ~19mins

### DIFF
--- a/app/stores/site.js
+++ b/app/stores/site.js
@@ -138,8 +138,14 @@ export const useSiteStore = defineStore('site', {
         },
         // Every theme read goes through resolveTheme — see app/utils/resolve-theme.js for the
         // precedence, per-leaf merge, hero-derive, and totality rules.
+        //
+        // The Drupal-authored theme is handed in from `this.biolandSettings`, the depth-7
+        // camelCased copy built in server/utils/context-unified.ts and passed through
+        // `initialize`. It is deliberately NOT read off `this.config.runTime.biolandSettings`:
+        // that copy is only camelCased by a statement sitting after the context builder's
+        // `return`, so it is dead code and the raw snake_case keys would not match.
         theme(){
-            return resolveTheme(this.config);
+            return resolveTheme(this.config, this.biolandSettings?.theme);
         },
         primaryColor(){
             return this.theme.color.primary;

--- a/app/utils/resolve-theme.js
+++ b/app/utils/resolve-theme.js
@@ -9,12 +9,41 @@
  *
  * ## Precedence (leg order, highest first)
  *
- *   1. site `config.theme`
- *   2. `config.runTime.theme` (the network-level theme)
- *   3. code defaults (below)
+ *   1. `biolandSettings.theme` (Drupal-authored, per-site)
+ *   2. site `config.theme`
+ *   3. `config.runTime.theme` (the network-level theme)
+ *   4. code defaults (below)
  *
- * NOTE: p02-01 adds the `biolandSettings.theme` leg *in front* of `config.theme`. The leg list in
- * `resolveTheme` is the seam for that change — add the leg, change nothing else.
+ * Leg 1 is the Drupal editor's authored theme, added by p02-01 (BL-885). It is passed in by the
+ * caller rather than read off `config`, because the only camelCased copy of `biolandSettings` the
+ * app may rely on is `siteStore.biolandSettings` — see "Input keys are post-camelCase" below.
+ *
+ * ## Absence is fall-through, never an error
+ *
+ * `biolandSettings` is attached best-effort by dmsm, which swallows Drupal errors, and no site
+ * carries an authored theme until an editor saves one. So the authored leg is absent far more
+ * often than not: `undefined`, `null`, a `biolandSettings` with no `theme` key, and an empty
+ * `theme` object all mean "this leg supplies nothing" and leave every leaf to the legs below.
+ * An unseeded site therefore resolves byte-identically to the three-leg result. This also covers
+ * the accepted flicker in ADR 0012: a Drupal blip drops the key for one cache window and the site
+ * briefly reverts to fallback branding. That is accepted behaviour, not a condition to throw on.
+ *
+ * ## Input keys are post-camelCase (depth 7)
+ *
+ * Drupal authors snake_case (`back_ground.secondary`, `mega_menu.max_rows_per_column`). dmsm
+ * passes those through unchanged — its SQL is an exact match on `name = 'bioland.settings'` and it
+ * assigns the whole config object without touching keys. The head does all case conversion, in
+ * `server/utils/context-unified.ts`, which camelCases to depth 7 into the `biolandSettings` field
+ * of the unified context. That transformed copy reaches the app as `siteStore.biolandSettings`.
+ * This resolver therefore sees `backGround`, never `back_ground`, and every fixture asserts the
+ * transformed shape.
+ *
+ * ## Untrusted input
+ *
+ * The authored leg is a row from a Drupal database that site editors can write. Keys that alias
+ * the prototype chain (`__proto__`, `constructor`, `prototype`) are dropped at both the group and
+ * the leaf level — see `isSafeKey`. They are dropped for every leg, not just the authored one,
+ * since a leg's trust level is not the resolver's to assume.
  *
  * ## Merge rule: per-leaf, not per-object
  *
@@ -73,6 +102,9 @@
  * a caller mutating the resolved theme cannot corrupt the shared site config.
  *
  * @param {object|null|undefined} config - the site config (`siteStore.config`).
+ * @param {object|null|undefined} authoredTheme - the Drupal-authored theme, i.e.
+ *   `siteStore.biolandSettings?.theme`, already camelCased to depth 7. Absent for every site that
+ *   has never had a theme saved, which today is the entire fleet.
  * @returns {object} the resolved theme. Never null, never throws.
  */
 
@@ -134,10 +166,34 @@ const LEAF_VALIDATORS = Object.freeze({
 
 const isPlainObject = value => typeof value === 'object' && value !== null && !Array.isArray(value);
 
+/**
+ * Keys that alias the prototype chain. The authored leg is untrusted editor input, and these are
+ * dropped before any key is used as a lookup index or copied onto the result.
+ *
+ * This is a security control, not a tidiness rule. On the unguarded resolver each of these is a
+ * hard crash, which for a theme read on every page is a total render failure:
+ *
+ * - `{ megaMenu: { __proto__: {...} } }` — `LEAF_VALIDATORS.megaMenu['__proto__']` resolves up the
+ *   prototype chain to `Object.prototype`, which is truthy but not callable, so the validator call
+ *   throws `TypeError: isUsable is not a function`.
+ * - `{ __proto__: {...} }` / `{ constructor: {...} }` at the top level — `CONTRACT_LEAVES[group]`
+ *   likewise resolves to an inherited value, and spreading it throws `TypeError: ... is not
+ *   iterable`, so the `|| []` fallback never fires.
+ *
+ * Filtering the keys out of the group and leaf unions closes both, and keeps a hostile key from
+ * being written onto the result even where the lookup would not have thrown.
+ */
+const DANGEROUS_KEYS = Object.freeze(['__proto__', 'constructor', 'prototype']);
+
+const isSafeKey = key => !DANGEROUS_KEYS.includes(key);
+
+/** Own, prototype-safe keys of a plain object. */
+const safeKeys = object => Object.keys(object).filter(isSafeKey);
+
 /** Deep clone of JSON-shaped data. Keeps the result free of live references into the input config. */
 const cloneValue = (value) => {
     if (Array.isArray(value))    return value.map(cloneValue);
-    if (isPlainObject(value))    return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, cloneValue(v)]));
+    if (isPlainObject(value))    return Object.fromEntries(safeKeys(value).map(k => [k, cloneValue(value[k])]));
 
     return value;
 };
@@ -162,12 +218,12 @@ const resolveLeaf = (legs, group, leaf) => {
 };
 
 /** Union of the group names any leg defines, plus every contract group. */
-const collectGroups = legs => [...new Set([...CONTRACT_GROUPS, ...legs.flatMap(leg => Object.keys(leg || {}))])];
+const collectGroups = legs => [...new Set([...CONTRACT_GROUPS, ...legs.flatMap(leg => safeKeys(leg || {}))])];
 
 /** Union of the leaf names any leg defines under `group`, plus that group's contract leaves. */
 const collectLeaves = (legs, group) => [...new Set([
     ...(CONTRACT_LEAVES[group] || []),
-    ...legs.flatMap(leg => (isPlainObject(leg?.[group]) ? Object.keys(leg[group]) : []))
+    ...legs.flatMap(leg => (isPlainObject(leg?.[group]) ? safeKeys(leg[group]) : []))
 ])];
 
 /**
@@ -199,8 +255,8 @@ const resolveHeroPrimary = (authored, color) => {
     return [0, 1].map(i => (isPresent(source[i]) ? source[i] : derived[i]));
 };
 
-export function resolveTheme(config) {
-    const legs = [config?.theme, config?.runTime?.theme, THEME_DEFAULTS].filter(isPlainObject);
+export function resolveTheme(config, authoredTheme) {
+    const legs = [authoredTheme, config?.theme, config?.runTime?.theme, THEME_DEFAULTS].filter(isPlainObject);
 
     const resolved = {};
 

--- a/app/utils/resolve-theme.js
+++ b/app/utils/resolve-theme.js
@@ -52,8 +52,7 @@
  * network leg. A whole-object merge would blank out every key the site did not restate.
  *
  * Groups the resolver does not know about pass through untouched, so callers reading keys outside
- * the contract (for example `color.secondaryTextOver`, `homePageWidgets.columns`,
- * `megaMenu.forums`) keep working.
+ * the contract (for example `color.secondaryTextOver`, `homePageWidgets.news`) keep working.
  *
  * ## Presence, not truthiness — with three validated leaves
  *
@@ -114,17 +113,24 @@ const THEME_DEFAULTS = Object.freeze({
     megaMenu: { maxColumns: 5 }        // was hardcoded as `|| 5` at schema-org.js:1152 and drop-down.vue:63
 });
 
-/** Contract groups that must always exist on the result so callers cannot crash on a missing group. */
-const CONTRACT_GROUPS = Object.freeze(['color', 'backGround', 'hero', 'megaMenu', 'i18n', 'homePageWidgets']);
-
 /** Contract leaves, per group, that must always be own properties of the result. */
 const CONTRACT_LEAVES = Object.freeze({
-    color     : ['primary', 'secondary'],
-    backGround: ['secondary'],
-    hero      : ['primary'],
-    megaMenu  : ['maxColumns', 'maxRowsPerColumn', 'horizontalCardMax', 'forums'],
-    i18n      : ['maxLangBeforeWrap']
+    color          : ['primary', 'secondary'],
+    backGround     : ['secondary'],
+    hero           : ['primary'],
+    megaMenu       : ['maxColumns', 'maxRowsPerColumn', 'horizontalCardMax', 'forums'],
+    i18n           : ['maxLangBeforeWrap'],
+    homePageWidgets: ['columns']
 });
+
+/**
+ * Contract groups that must always exist on the result so callers cannot crash on a missing group.
+ *
+ * Derived from `CONTRACT_LEAVES` rather than listed separately, so the two can never drift. Every
+ * contract group therefore has at least one contract leaf, which is what guarantees the group is
+ * always built by the leaf path below and never falls to `resolveOpaqueGroup`.
+ */
+const CONTRACT_GROUPS = Object.freeze(Object.keys(CONTRACT_LEAVES));
 
 const isPresent = value => value !== undefined && value !== null;
 
@@ -135,11 +141,22 @@ const isUsableColor = value => typeof value === 'string' && value.trim() !== '';
 const isUsableColumnCount = value => Number.isFinite(Number(value)) && Number(value) >= 1;
 
 /**
+ * The home page renders one grid column per entry of `homePageWidgets.columns`
+ * (`v-for="(column, i) in columnsOfWidgetComponents"` in `page/home-chm.vue`). Vue's `v-for` over a
+ * *number* renders that many nodes and over a *string* iterates per character, so an authored
+ * `columns: 50000000` would hang or OOM the home page, SSR included. Only an array is a usable
+ * column list; anything else falls through to the next leg.
+ */
+const isUsableColumnList = value => Array.isArray(value);
+
+/**
  * Per-leaf validators — the deliberate exceptions to the presence rule.
  *
- * A leaf earns a validator only when BOTH hold: its pre-refactor read used `||` (so falsy values
+ * A leaf earns a validator when BOTH hold: its pre-refactor read used `||` (so falsy values
  * already fell through and no live site can be relying on one), and a falsy-but-present value
- * produces a broken render rather than a meaningful setting. That is exactly three leaves:
+ * produces a broken render rather than a meaningful setting. That is three leaves — plus one
+ * type guard, `homePageWidgets.columns`, which is here because a wrong-typed value is a render
+ * DoS rather than merely a broken setting (see `isUsableColumnList`).
  *
  * - `color.primary`   — was `|| '#009edb'` at site.js:140. `''` voids every `solid ${primary}`
  *                       border and `background: ${primary}` declaration that consumes it.
@@ -148,6 +165,9 @@ const isUsableColumnCount = value => Number.isFinite(Number(value)) && Number(va
  * - `megaMenu.maxColumns` — was `|| 5` at schema-org.js:1152 and drop-down.vue:63. `0` makes
  *                       `organizeSectionsIntoRows` collapse every section into one unbounded row
  *                       (`Math.min(span, 0) === 0`, so the wrap branch never fires).
+ * - `homePageWidgets.columns` — not a `||` case: it is a type guard against a non-array authored
+ *                       value reaching a `v-for`, which Vue would iterate numerically or per
+ *                       character. See `isUsableColumnList`.
  *
  * Explicitly NOT validated, with reasons:
  * - `backGround.secondary` — its old read had no `||`, so `''` was already passed through and
@@ -160,8 +180,9 @@ const isUsableColumnCount = value => Number.isFinite(Number(value)) && Number(va
  *   contract note in the header comment for the *unset* case.
  */
 const LEAF_VALIDATORS = Object.freeze({
-    color   : { primary: isUsableColor, secondary: isUsableColor },
-    megaMenu: { maxColumns: isUsableColumnCount }
+    color          : { primary: isUsableColor, secondary: isUsableColor },
+    megaMenu       : { maxColumns: isUsableColumnCount },
+    homePageWidgets: { columns: isUsableColumnList }
 });
 
 const isPlainObject = value => typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -170,8 +191,9 @@ const isPlainObject = value => typeof value === 'object' && value !== null && !A
  * Keys that alias the prototype chain. The authored leg is untrusted editor input, and these are
  * dropped before any key is used as a lookup index or copied onto the result.
  *
- * This is a security control, not a tidiness rule. On the unguarded resolver each of these is a
- * hard crash, which for a theme read on every page is a total render failure:
+ * This is a security control, not a tidiness rule. `__proto__` and `constructor` are live vectors:
+ * on the unguarded resolver each is a hard crash, which for a theme read on every page is a total
+ * render failure.
  *
  * - `{ megaMenu: { __proto__: {...} } }` — `LEAF_VALIDATORS.megaMenu['__proto__']` resolves up the
  *   prototype chain to `Object.prototype`, which is truthy but not callable, so the validator call
@@ -180,14 +202,31 @@ const isPlainObject = value => typeof value === 'object' && value !== null && !A
  *   likewise resolves to an inherited value, and spreading it throws `TypeError: ... is not
  *   iterable`, so the `|| []` fallback never fires.
  *
- * Filtering the keys out of the group and leaf unions closes both, and keeps a hostile key from
- * being written onto the result even where the lookup would not have thrown.
+ * `'prototype'` causes no crash of its own — `CONTRACT_LEAVES['prototype']` and
+ * `LEAF_VALIDATORS[group]?.['prototype']` are both `undefined` on a plain object, since plain
+ * objects do not inherit a `prototype` property. It is kept as defence in depth only.
+ *
+ * The guard is load-bearing rather than belt-and-braces because the camelCase pass upstream does
+ * not neutralise these keys: `change-case/keys` rewrites a *top-level* `__proto__` to `proto`, but
+ * leaves `constructor` verbatim at every depth, leaves `__proto__` verbatim below the top level,
+ * and stops converting at depth 7 — so hostile keys still reach this resolver.
+ *
+ * Filtering the keys out of the group and leaf unions closes both live vectors, and keeps a
+ * hostile key from being written onto the result even where the lookup would not have thrown.
  */
 const DANGEROUS_KEYS = Object.freeze(['__proto__', 'constructor', 'prototype']);
 
 const isSafeKey = key => !DANGEROUS_KEYS.includes(key);
 
-/** Own, prototype-safe keys of a plain object. */
+/**
+ * Own, prototype-safe keys of a plain object.
+ *
+ * Note: keys arrive already camelCased by `server/utils/context-unified.ts`, and that conversion is
+ * lossy — `back_ground` and `backGround` both become `backGround`, so one silently overwrites the
+ * other with no error. It is a correctness wart, not a privilege boundary: an editor can only
+ * collide onto a key they could have authored directly, so nothing is reachable that was not
+ * already. Left as-is deliberately — erroring here would be a contract change.
+ */
 const safeKeys = object => Object.keys(object).filter(isSafeKey);
 
 /** Deep clone of JSON-shaped data. Keeps the result free of live references into the input config. */
@@ -232,6 +271,9 @@ const collectLeaves = (legs, group) => [...new Set([
  * whole-object getter kept `theme.foo = {}`, and a caller doing `theme.foo.bar` without an optional
  * chain must not start throwing. Any plain object reaching here is empty by construction, since a
  * non-empty one would have produced leaves.
+ *
+ * Only ever reached for a NON-contract group: every contract group has contract leaves, so it is
+ * always built by the leaf path instead.
  */
 const resolveOpaqueGroup = (legs, group) => {
     for (const leg of legs) {
@@ -239,8 +281,6 @@ const resolveOpaqueGroup = (legs, group) => {
 
         if (isPresent(value)) return cloneValue(value);
     }
-
-    return undefined;
 };
 
 /**
@@ -269,7 +309,6 @@ export function resolveTheme(config, authoredTheme) {
             const opaque = resolveOpaqueGroup(legs, group);
 
             if (isPresent(opaque)) resolved[group] = opaque;
-            else if (CONTRACT_GROUPS.includes(group)) resolved[group] = {};
 
             continue;
         }

--- a/docs/debt.md
+++ b/docs/debt.md
@@ -1,0 +1,11 @@
+# Tech debt ledger
+
+Intentionally deferred issues, their impact ceiling, and the trigger that would justify a fix.
+Format and rules: the `docs-debt` skill.
+
+> This file is also created on branch `docs/BL-882-p01-02-adr-head-theme-resolution` with its own
+> rows. The two tables reconcile when both branches land; neither was merged into the other.
+
+| ID | Date | Source | Location | Issue | Ceiling / Impact | Fix trigger | Priority | Complexity | Status |
+|----|------|--------|----------|-------|-------------------|-------------|----------|------------|--------|
+| `BL-885-1` | 2026-08-24 | BL-885 review cycle 2 | `app/utils/resolve-theme.js` (`resolveLeaf`), pinned by the `[characterisation]` test in `tests/unit/app/utils/resolve-theme.test.ts` | An authored `homePageWidgets.columns: []` is a present, usable array, so it wins the precedence chain and the CHM home page renders no widget columns; the network leg is not restored. Whether an empty array should mean "no widgets" (current behaviour, and the intended reading — the same logic that makes `maxRowsPerColumn: 0` mean "unlimited") or should fall through was deliberately not decided in BL-885. **Tension to reconcile:** ADR 0012 section W2a validates the outer `columns` length to *exactly 3*, which contradicts accepting `[]` at all. Unresolved on purpose — someone must reconcile the resolver's fall-through rule against the ADR's length validation and pick one. | A site that clears every column loses its home widgets with no way to inherit the network's back; or the W2a validator rejects a value the resolver accepts, so the two layers disagree | An editor reports missing home widgets after clearing columns, or W2a validation is implemented and hits the mismatch | P3 | S | open |

--- a/tests/e2e/theme-precedence.test.ts
+++ b/tests/e2e/theme-precedence.test.ts
@@ -47,6 +47,23 @@ import { getE2EBaseURL } from './e2e-targets'
  *     so there is an observable fall-through leaf. Authoring both colours, as the original did,
  *     left the fall-through half of the test name with nothing to observe.
  *
+ * ## Why the fixture does not also author `megaMenu.maxColumns`
+ *
+ * An earlier draft of this fixture authored `megaMenu.maxColumns: 4` alongside the colour, but
+ * nothing observed it - inert fixture data that would still pass if the resolver stopped honouring
+ * `maxColumns` entirely. It was dropped rather than asserted: `maxColumns` has no CSS-variable or
+ * inline-style projection (see `useTheme` / `app/composables/theme.js`) - its only DOM effect is
+ * structural, in `app/components/page/header/mega-menu/drop-down.vue`, where it caps how many
+ * `.menu-section` elements get bin-packed into each `.mm-row`. That dropdown is `v-if`-gated
+ * behind a top-level nav toggle, so it is absent from the page until a specific menu item is
+ * opened, and whether 4 vs. the default 5 columns produces a different row count depends on that
+ * menu's live section count - data this spec does not control and would have to separately
+ * intercept and fabricate to make the assertion reliably discriminating. Doing that would assert on
+ * invented menu data instead of the real page, and the only way to read the result is counting
+ * elements by selector, which is exactly the DOM-structure coupling this suite avoids. `color.primary`
+ * already proves the per-leaf merge reaches the page; a second, harder-to-land leaf on a different
+ * contract group is not worth that cost.
+ *
  * ## Header caveat
  *
  * When fulfilling with a modified body, the inherited `content-encoding` and `content-length`
@@ -66,8 +83,7 @@ test.use({
  * the fall-through leaf this spec observes.
  */
 const AUTHORED_THEME = {
-  color   : { primary: '#ff00e7' },
-  megaMenu: { maxColumns: 4 },
+  color: { primary: '#ff00e7' },
 }
 
 /** The context payload the site plugin initialises the store from. */

--- a/tests/e2e/theme-precedence.test.ts
+++ b/tests/e2e/theme-precedence.test.ts
@@ -1,0 +1,151 @@
+import { expect, test } from '@nuxt/test-utils/playwright'
+
+import { getE2EBaseURL } from './e2e-targets'
+
+/**
+ * BL-885 — `biolandSettings.theme` precedence, end to end.
+ *
+ * Authored leaves win; unauthored leaves fall through to today's render. The unit suites pin the
+ * merge rule and the depth-7 transform in isolation; this spec proves the wiring actually reaches
+ * the rendered page, which is the one thing a unit test cannot show.
+ *
+ * ## Method
+ *
+ * The site config is fetched from dmsm by the Nitro server, so the spec intercepts that response
+ * and injects an author-shaped `biolandSettings.theme` into it. Two runs against the same route:
+ *
+ *   1. Baseline, no interception — capture what the site renders today.
+ *   2. Injected — assert the authored leaves changed and the unauthored leaves did not.
+ *
+ * Asserting run 2 against run 1 rather than against hardcoded colours keeps the spec valid as the
+ * network theme evolves. No live site carries an authored theme today, so run 1 is by definition
+ * the fall-through render.
+ *
+ * ## Header caveat
+ *
+ * When fulfilling with a modified body, the inherited `content-encoding` and `content-length`
+ * headers are dropped. Re-using them ships a plain-JSON body labelled gzip with the wrong length,
+ * which fails behind a gzip proxy while passing locally. See `stripBodyHeaders`.
+ *
+ * ## Run status
+ *
+ * Authored under p02-01. p03-01 (local verification gate) owns running it: this branch has no
+ * running stack to point `getE2EBaseURL()` at, so the run is deferred there. `yarn test:e2e --list`
+ * must enumerate it cleanly from here.
+ */
+
+test.use({
+  baseURL: getE2EBaseURL(),
+})
+
+/** Author-shaped theme, post-camelCase — the shape context-unified.ts hands to the app. */
+const AUTHORED_THEME = {
+  color   : { primary: '#7b6f82', secondary: '#889262' },
+  megaMenu: { maxColumns: 4 },
+}
+
+/**
+ * Headers that describe the ORIGINAL body and must not be carried onto a modified one.
+ * `content-length` would be wrong; `content-encoding` would claim a compression that is not there.
+ */
+const stripBodyHeaders = (headers: Record<string, string>) =>
+  Object.fromEntries(
+    Object.entries(headers).filter(([name]) => !['content-encoding', 'content-length'].includes(name.toLowerCase())),
+  )
+
+/**
+ * Theme colours as actually rendered.
+ *
+ * `useTheme` (app/composables/theme.js) applies the resolved theme as INLINE styles on individual
+ * elements — `--bs-primary`, `border-top: <primary> .5rem solid`, `background-color: <secondary>`
+ * — rather than as custom properties on `:root`. So the read scans the document for those inline
+ * declarations and returns the distinct values, which is stable across component changes in a way
+ * that pinning one selector is not.
+ */
+const readThemeVars = (page: any) =>
+  page.evaluate(() => {
+    const distinct = (values: string[]) => [...new Set(values.filter(Boolean))].sort()
+
+    const styled = [...document.querySelectorAll<HTMLElement>('[style]')]
+
+    return {
+      primary   : distinct(styled.map(el => el.style.getPropertyValue('--bs-primary').trim().toLowerCase())),
+      background: distinct(styled.map(el => el.style.backgroundColor.trim().toLowerCase())),
+    }
+  })
+
+/** Playwright reports colours as `rgb(...)`; the fixture authors hex. */
+const toRgb = (hex: string) => {
+  const [r, g, b] = [1, 3, 5].map(i => parseInt(hex.slice(i, i + 2), 16))
+
+  return `rgb(${r}, ${g}, ${b})`
+}
+
+test.describe('biolandSettings.theme precedence', () => {
+
+  test('an authored theme wins on its own leaves and falls through on the rest', async ({ page }) => {
+    // ---- Run 1: baseline. No site on the fleet authors a theme, so this is the fall-through render.
+    await page.goto('/', { waitUntil: 'networkidle' })
+
+    const baseline = await readThemeVars(page)
+
+    expect(baseline.primary.length, 'baseline must expose a primary colour to compare against').toBeGreaterThan(0)
+
+    // ---- Run 2: inject an authored theme into the site config response.
+    await page.route('**/config/**', async (route) => {
+      const response = await route.fetch()
+      const config   = await response.json()
+
+      config.runTime = config.runTime || {}
+      config.runTime.biolandSettings = {
+        ...(config.runTime.biolandSettings || {}),
+        theme: AUTHORED_THEME,
+      }
+
+      await route.fulfill({
+        status     : response.status(),
+        headers    : stripBodyHeaders(response.headers()),
+        contentType: 'application/json',
+        body       : JSON.stringify(config),
+      })
+    })
+
+    await page.goto('/', { waitUntil: 'networkidle' })
+
+    const themed = await readThemeVars(page)
+
+    // Authored leaves win: the authored primary is what the page now paints with.
+    expect(themed.primary).toContain(AUTHORED_THEME.color.primary)
+    expect(themed.primary).not.toEqual(baseline.primary)
+
+    // And the authored secondary reaches the backgrounds `bgStyle` drives.
+    expect(themed.background).toContain(toRgb(AUTHORED_THEME.color.secondary))
+  })
+
+  test('a site with no authored theme renders exactly as it does today', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'networkidle' })
+
+    const before = await readThemeVars(page)
+
+    // biolandSettings present but carrying no `theme` key — the whole fleet's current state.
+    await page.route('**/config/**', async (route) => {
+      const response = await route.fetch()
+      const config   = await response.json()
+
+      config.runTime = config.runTime || {}
+      config.runTime.biolandSettings = { ...(config.runTime.biolandSettings || {}) }
+      delete config.runTime.biolandSettings.theme
+
+      await route.fulfill({
+        status     : response.status(),
+        headers    : stripBodyHeaders(response.headers()),
+        contentType: 'application/json',
+        body       : JSON.stringify(config),
+      })
+    })
+
+    await page.goto('/', { waitUntil: 'networkidle' })
+
+    expect(await readThemeVars(page)).toEqual(before)
+  })
+})

--- a/tests/e2e/theme-precedence.test.ts
+++ b/tests/e2e/theme-precedence.test.ts
@@ -11,8 +11,10 @@ import { getE2EBaseURL } from './e2e-targets'
  *
  * ## Method
  *
- * The site config is fetched from dmsm by the Nitro server, so the spec intercepts that response
- * and injects an author-shaped `biolandSettings.theme` into it. Two runs against the same route:
+ * `app/plugins/site.js` fetches `/api/context/{siteCode}/{locale}` and hands the response straight
+ * to `siteStore.initialize`. That plugin runs on the CLIENT as well as during SSR, so the browser
+ * makes that request and Playwright can intercept it. The spec injects an author-shaped
+ * `biolandSettings.theme` into that response. Two runs against the same route:
  *
  *   1. Baseline, no interception — capture what the site renders today.
  *   2. Injected — assert the authored leaves changed and the unauthored leaves did not.
@@ -21,28 +23,55 @@ import { getE2EBaseURL } from './e2e-targets'
  * network theme evolves. No live site carries an authored theme today, so run 1 is by definition
  * the fall-through render.
  *
+ * ## Two defects this spec was rewritten to fix (BL-886 gate, first ever execution)
+ *
+ * 1. **It injected into the wrong key.** The original fixture wrote
+ *    `config.runTime.biolandSettings.theme`. `app/stores/site.js` deliberately does NOT read the
+ *    theme from there (see the comment above its `theme` getter) — it reads the top-level
+ *    `biolandSettings` handed through `initialize`. Nothing the old fixture wrote could ever have
+ *    reached the page.
+ *
+ * 2. **The fixture colour collided with the tenant.** It authored `#7b6f82`, which is the target
+ *    tenant's OWN live primary. That hid defect 1 entirely: `toContain(authored)` passed
+ *    trivially because the page painted that colour with nothing injected. The spec could not
+ *    tell an injected value from a baseline one, so it proved nothing about the feature it exists
+ *    to prove.
+ *
+ * Three things keep that from recurring:
+ *
+ *   - The fixture uses a synthetic sentinel colour no brand palette would carry.
+ *   - The spec ASSERTS the sentinel is absent from the baseline render before asserting it took
+ *     effect, so a future tenant-theme change fails loudly rather than silently hollowing the
+ *     spec out again.
+ *   - The fixture authors `color.primary` ONLY. `color.secondary` is deliberately left unauthored
+ *     so there is an observable fall-through leaf. Authoring both colours, as the original did,
+ *     left the fall-through half of the test name with nothing to observe.
+ *
  * ## Header caveat
  *
  * When fulfilling with a modified body, the inherited `content-encoding` and `content-length`
  * headers are dropped. Re-using them ships a plain-JSON body labelled gzip with the wrong length,
  * which fails behind a gzip proxy while passing locally. See `stripBodyHeaders`.
- *
- * ## Run status
- *
- * Authored under p02-01. p03-01 (local verification gate) owns running it: this branch has no
- * running stack to point `getE2EBaseURL()` at, so the run is deferred there. `yarn test:e2e --list`
- * must enumerate it cleanly from here.
  */
 
 test.use({
   baseURL: getE2EBaseURL(),
 })
 
-/** Author-shaped theme, post-camelCase — the shape context-unified.ts hands to the app. */
+/**
+ * Author-shaped theme, post-camelCase — the shape context-unified.ts hands to the app.
+ *
+ * `color.primary` is a synthetic sentinel, not a plausible brand colour, so it cannot coincide
+ * with whatever the target tenant already paints. `color.secondary` is intentionally ABSENT: it is
+ * the fall-through leaf this spec observes.
+ */
 const AUTHORED_THEME = {
-  color   : { primary: '#7b6f82', secondary: '#889262' },
+  color   : { primary: '#ff00e7' },
   megaMenu: { maxColumns: 4 },
 }
+
+/** The context payload the site plugin initialises the store from. */
+const CONTEXT_ROUTE = '**/api/context/**'
 
 /**
  * Headers that describe the ORIGINAL body and must not be carried onto a modified one.
@@ -52,6 +81,22 @@ const stripBodyHeaders = (headers: Record<string, string>) =>
   Object.fromEntries(
     Object.entries(headers).filter(([name]) => !['content-encoding', 'content-length'].includes(name.toLowerCase())),
   )
+
+/** Intercept the context response and hand `mutate` the parsed payload to edit in place. */
+const interceptContext = (page: any, mutate: (context: any) => void) =>
+  page.route(CONTEXT_ROUTE, async (route: any) => {
+    const response = await route.fetch()
+    const context  = await response.json()
+
+    mutate(context)
+
+    await route.fulfill({
+      status     : response.status(),
+      headers    : stripBodyHeaders(response.headers()),
+      contentType: 'application/json',
+      body       : JSON.stringify(context),
+    })
+  })
 
 /**
  * Theme colours as actually rendered.
@@ -83,6 +128,10 @@ const toRgb = (hex: string) => {
 
 test.describe('biolandSettings.theme precedence', () => {
 
+  // Each spec loads the route twice against a `nuxt dev` server, so the first compile alone can
+  // outrun Playwright's 30s default. This is slowness, not flake — the waits stay deterministic.
+  test.describe.configure({ timeout: 120_000 })
+
   test('an authored theme wins on its own leaves and falls through on the rest', async ({ page }) => {
     // ---- Run 1: baseline. No site on the fleet authors a theme, so this is the fall-through render.
     await page.goto('/', { waitUntil: 'networkidle' })
@@ -90,36 +139,36 @@ test.describe('biolandSettings.theme precedence', () => {
     const baseline = await readThemeVars(page)
 
     expect(baseline.primary.length, 'baseline must expose a primary colour to compare against').toBeGreaterThan(0)
+    expect(baseline.background.length, 'baseline must expose a background colour to compare against').toBeGreaterThan(0)
 
-    // ---- Run 2: inject an authored theme into the site config response.
-    await page.route('**/config/**', async (route) => {
-      const response = await route.fetch()
-      const config   = await response.json()
+    // ---- Fixture guard. If the tenant already paints the sentinel, every assertion below would be
+    // satisfied by the baseline alone and the spec would prove nothing. Fail here, loudly, instead.
+    expect(baseline.primary, 'fixture primary collides with the tenant rendered primary — pick another sentinel')
+      .not.toContain(AUTHORED_THEME.color.primary)
+    expect(baseline.background, 'fixture primary collides with a rendered background — pick another sentinel')
+      .not.toContain(toRgb(AUTHORED_THEME.color.primary))
 
-      config.runTime = config.runTime || {}
-      config.runTime.biolandSettings = {
-        ...(config.runTime.biolandSettings || {}),
-        theme: AUTHORED_THEME,
-      }
-
-      await route.fulfill({
-        status     : response.status(),
-        headers    : stripBodyHeaders(response.headers()),
-        contentType: 'application/json',
-        body       : JSON.stringify(config),
-      })
+    // ---- Run 2: inject an authored theme into the context response.
+    await interceptContext(page, (context) => {
+      context.biolandSettings = { ...(context.biolandSettings || {}), theme: AUTHORED_THEME }
     })
 
     await page.goto('/', { waitUntil: 'networkidle' })
 
     const themed = await readThemeVars(page)
 
-    // Authored leaves win: the authored primary is what the page now paints with.
-    expect(themed.primary).toContain(AUTHORED_THEME.color.primary)
-    expect(themed.primary).not.toEqual(baseline.primary)
+    // Authored leaf wins: the sentinel primary is what the page now paints with. Because the guard
+    // above proved the baseline did not carry it, this can only have come from the injection —
+    // neutralise the authored leg and this assertion fails.
+    expect(themed.primary, 'the authored primary did not reach the rendered page')
+      .toContain(AUTHORED_THEME.color.primary)
+    expect(themed.primary, 'the themed render is indistinguishable from the baseline')
+      .not.toEqual(baseline.primary)
 
-    // And the authored secondary reaches the backgrounds `bgStyle` drives.
-    expect(themed.background).toContain(toRgb(AUTHORED_THEME.color.secondary))
+    // Unauthored leaf falls through: `color.secondary` was never authored, so every background the
+    // tenant painted at baseline — the secondary `bgStyle` drives among them — must still be there.
+    expect(themed.background, 'an unauthored secondary should have fallen through to the tenant value')
+      .toEqual(expect.arrayContaining(baseline.background))
   })
 
   test('a site with no authored theme renders exactly as it does today', async ({ page }) => {
@@ -128,20 +177,9 @@ test.describe('biolandSettings.theme precedence', () => {
     const before = await readThemeVars(page)
 
     // biolandSettings present but carrying no `theme` key — the whole fleet's current state.
-    await page.route('**/config/**', async (route) => {
-      const response = await route.fetch()
-      const config   = await response.json()
-
-      config.runTime = config.runTime || {}
-      config.runTime.biolandSettings = { ...(config.runTime.biolandSettings || {}) }
-      delete config.runTime.biolandSettings.theme
-
-      await route.fulfill({
-        status     : response.status(),
-        headers    : stripBodyHeaders(response.headers()),
-        contentType: 'application/json',
-        body       : JSON.stringify(config),
-      })
+    await interceptContext(page, (context) => {
+      context.biolandSettings = { ...(context.biolandSettings || {}) }
+      delete context.biolandSettings.theme
     })
 
     await page.goto('/', { waitUntil: 'networkidle' })

--- a/tests/unit/app/utils/fixtures/theme-effective-values.json
+++ b/tests/unit/app/utils/fixtures/theme-effective-values.json
@@ -1,0 +1,98 @@
+{
+  "_comment": [
+    "Input-config to expected-effective-VALUE cases for app/utils/resolve-theme.js.",
+    "Every key here is post-camelCase (depth 7). The module authors in snake case; the head",
+    "transforms it in server/utils/context-unified.ts before the resolver ever sees it, so a",
+    "snake_case theme key in this file is a defect, not a variant.",
+    "`authoredTheme` is siteStore.biolandSettings?.theme — the Drupal-authored leg, leg 1."
+  ],
+
+  "networkTheme": {
+    "color": { "primary": "#009edb", "primaryTextOver": "#ffffff", "secondary": "#16c56e", "secondaryTextOver": "#ffffff" },
+    "hero": { "primary": ["#009edb", "#16c56e"] },
+    "text": { "primary": "#222222", "secondary": "#4D4D4D" },
+    "backGround": { "primary": "", "secondary": "#F2F2F2", "tertiary": "#4D4D4D" },
+    "megaMenu": { "forums": true, "maxColumns": 5, "maxRowsPerColumn": 6, "horizontalCardMax": 3, "horizontalCardWrap": false },
+    "i18n": { "maxLangBeforeWrap": 6 },
+    "homePageWidgets": { "news": true, "columns": [["panorama", "gbif"], ["implementation"], ["forums"]] }
+  },
+
+  "cases": [
+    {
+      "name": "full-copy site — an authored theme restating every group wins outright",
+      "authoredTheme": {
+        "color": { "primary": "#7b6f82", "secondary": "#889262" },
+        "backGround": { "secondary": "#EEEEEE" },
+        "megaMenu": { "forums": true, "maxColumns": 4, "maxRowsPerColumn": 8, "horizontalCardMax": 2 },
+        "i18n": { "maxLangBeforeWrap": 4 },
+        "homePageWidgets": { "columns": [["panorama"], ["implementation"], ["forums"]] }
+      },
+      "siteTheme": null,
+      "expected": {
+        "color.primary": "#7b6f82",
+        "color.secondary": "#889262",
+        "color.secondaryTextOver": "#ffffff",
+        "backGround.secondary": "#EEEEEE",
+        "megaMenu.maxColumns": 4,
+        "megaMenu.maxRowsPerColumn": 8,
+        "megaMenu.horizontalCardMax": 2,
+        "megaMenu.forums": true,
+        "i18n.maxLangBeforeWrap": 4,
+        "_comment_hero": "NOT derived from the authored colors. The network leg authors hero.primary, and ADR 0012 derives only when hero is absent from EVERY source, so the network hero passes through. A site wanting a matching hero must author one.",
+        "hero.primary": ["#009edb", "#16c56e"]
+      }
+    },
+
+    {
+      "name": "theme-less site — no authored leg at all, renders exactly as today",
+      "authoredTheme": null,
+      "siteTheme": null,
+      "expected": {
+        "color.primary": "#009edb",
+        "color.secondary": "#16c56e",
+        "color.secondaryTextOver": "#ffffff",
+        "backGround.secondary": "#F2F2F2",
+        "megaMenu.maxColumns": 5,
+        "megaMenu.maxRowsPerColumn": 6,
+        "megaMenu.horizontalCardMax": 3,
+        "megaMenu.forums": true,
+        "i18n.maxLangBeforeWrap": 6,
+        "hero.primary": ["#009edb", "#16c56e"]
+      }
+    },
+
+    {
+      "name": "be dual-block — authored hero.primary[1] #CBB279 is preserved, never re-derived",
+      "authoredTheme": {
+        "color": { "primary": "#7b6f82", "secondary": "#889262" },
+        "hero": { "primary": ["#7b6f82", "#CBB279"] }
+      },
+      "siteTheme": null,
+      "expected": {
+        "color.primary": "#7b6f82",
+        "color.secondary": "#889262",
+        "hero.primary": ["#7b6f82", "#CBB279"],
+        "backGround.secondary": "#F2F2F2",
+        "megaMenu.maxColumns": 5,
+        "i18n.maxLangBeforeWrap": 6
+      }
+    },
+
+    {
+      "name": "bsl falsy-but-meaningful — maxRowsPerColumn 0 and forums false both survive",
+      "authoredTheme": {
+        "megaMenu": { "maxRowsPerColumn": 0, "forums": false }
+      },
+      "siteTheme": null,
+      "expected": {
+        "megaMenu.maxRowsPerColumn": 0,
+        "megaMenu.forums": false,
+        "megaMenu.maxColumns": 5,
+        "megaMenu.horizontalCardMax": 3,
+        "color.primary": "#009edb",
+        "color.secondary": "#16c56e",
+        "hero.primary": ["#009edb", "#16c56e"]
+      }
+    }
+  ]
+}

--- a/tests/unit/app/utils/resolve-theme.test.ts
+++ b/tests/unit/app/utils/resolve-theme.test.ts
@@ -297,10 +297,18 @@ describe('resolveTheme', () => {
             expect(tags).toEqual(['a'])
         })
 
-        it('replaces a scalar-valued contract group with an empty object', () => {
+        it('keeps a null-valued contract group as an object with its contract leaves', () => {
             const theme = resolveTheme({ theme: { homePageWidgets: null }, runTime: { theme: {} } } as any)
 
             expect(theme.homePageWidgets).toEqual({})
+            expect(Object.prototype.hasOwnProperty.call(theme.homePageWidgets, 'columns')).toBe(true)
+            expect(theme.homePageWidgets.columns).toBeUndefined()
+        })
+
+        it('drops a non-contract group no leg supplies a present value for', () => {
+            const theme = resolveTheme({ theme: { text: null }, runTime: { theme: { text: null } } } as any)
+
+            expect(Object.prototype.hasOwnProperty.call(theme, 'text')).toBe(false)
         })
 
         it('ignores a non-object theme leg entirely', () => {
@@ -718,6 +726,65 @@ describe('resolveTheme — biolandSettings.theme leg (p02-01)', () => {
 
             expect(authored.color.primary).toBe('#7b6f82')
             expect(authored.homePageWidgets.columns).toEqual([['panorama']])
+        })
+    })
+    describe('homePageWidgets.columns — the home-page v-for boundary', () => {
+        const config = { runTime: { theme: networkTheme } }
+
+        /**
+         * Verbatim transcription of the only consumer, app/components/page/home-chm.vue:32:
+         *   const columnsOfWidgetComponents = computed(() => siteStore?.theme?.homePageWidgets?.columns)
+         * The template then does `v-for="(column, i) in columnsOfWidgetComponents"`. Vue's `v-for`
+         * over a number renders that many nodes and over a string iterates per character, so this
+         * is the value that must never be anything but an array or `undefined`.
+         */
+        const columnsOfWidgetComponents = (theme: any) => theme?.homePageWidgets?.columns
+
+        const hostileColumns = [
+            ['a number — v-for would render that many nodes', 50000000],
+            ['a string — v-for would iterate per character', 'x'.repeat(1000)],
+            ['a numeric string', '50000000'],
+            ['a plain object', { length: 50000000 }],
+            ['a boolean', true]
+        ] as const
+
+        for (const [label, columns] of hostileColumns) {
+            it(`rejects ${label}, so it never reaches the template`, () => {
+                const theme = resolveTheme(config, { homePageWidgets: { columns } } as any)
+                const value = columnsOfWidgetComponents(theme)
+
+                expect(value).not.toBe(columns)
+                expect(Array.isArray(value) || value === undefined, `${label} -> ${String(value)}`).toBe(true)
+                // The authored leg supplied nothing usable, so the network leg wins as normal.
+                expect(value).toEqual(networkTheme.homePageWidgets.columns)
+            })
+        }
+
+        it('with no lower leg to fall through to, a hostile columns resolves to undefined', () => {
+            const theme = resolveTheme({}, { homePageWidgets: { columns: 50000000 } } as any)
+
+            expect(columnsOfWidgetComponents(theme)).toBeUndefined()
+        })
+
+        it('a legitimate authored array still wins over the network leg', () => {
+            const authored = [['panorama'], ['forums']]
+            const theme    = resolveTheme(config, { homePageWidgets: { columns: authored } } as any)
+
+            expect(columnsOfWidgetComponents(theme)).toEqual(authored)
+        })
+
+        /**
+         * CHARACTERISATION TEST — pins behaviour as it is today, and asserts nothing about whether
+         * it is desirable. An authored empty `columns` is a present, usable array, so it wins and
+         * the home page renders no widget columns; the network leg is NOT restored. See ADR 0012
+         * W2a and the docs/debt.md row: W2a validates the outer `columns` length to exactly 3,
+         * which is in tension with accepting `[]`. Deliberately unresolved here.
+         */
+        it('[characterisation] an authored empty columns array currently wins over the lower leg', () => {
+            const theme = resolveTheme(config, { homePageWidgets: { columns: [] } } as any)
+
+            expect(columnsOfWidgetComponents(theme)).toEqual([])
+            expect(columnsOfWidgetComponents(theme)).not.toEqual(networkTheme.homePageWidgets.columns)
         })
     })
 })

--- a/tests/unit/app/utils/resolve-theme.test.ts
+++ b/tests/unit/app/utils/resolve-theme.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import { resolveTheme } from '../../../../app/utils/resolve-theme'
 
+import effectiveValues from './fixtures/theme-effective-values.json'
+
 /**
  * Value-preservation suite for the canonical theme resolver.
  *
@@ -397,5 +399,325 @@ describe('resolveTheme', () => {
                 else expect(theme.hero.primary).toEqual([theme.color.primary, theme.color.secondary])
             })
         }
+    })
+})
+
+/**
+ * ============================================================================================
+ * p02-01 (BL-885) — the `biolandSettings.theme` activation leg.
+ *
+ * Leg order becomes: authored > site config.theme > runTime.theme > code defaults.
+ *
+ * This is the MERGE pin — the second of the two depths this task keeps separate. It exercises the
+ * resolver's per-leaf rule against already-camelCased input and never touches the depth-7
+ * transform; that is pinned independently in
+ * tests/unit/server/utils/bioland-settings-camel-case.test.ts.
+ *
+ * Every key below is post-camelCase. A snake_case theme key in this file is a defect.
+ * ============================================================================================
+ */
+describe('resolveTheme — biolandSettings.theme leg (p02-01)', () => {
+
+    const siteConfig = { runTime: { theme: networkTheme } }
+
+    describe('precedence — an authored leaf outranks every leg below it', () => {
+
+        it('beats the network runTime.theme', () => {
+            const theme = resolveTheme(siteConfig, { color: { primary: '#7b6f82' } })
+
+            expect(theme.color.primary).toBe('#7b6f82')
+        })
+
+        it('beats the site config.theme', () => {
+            const config = { theme: { color: { primary: '#111111' } }, runTime: { theme: networkTheme } }
+            const theme  = resolveTheme(config, { color: { primary: '#7b6f82' } })
+
+            expect(theme.color.primary).toBe('#7b6f82')
+        })
+
+        it('beats the code defaults', () => {
+            // No site theme, no network theme — THEME_DEFAULTS would supply #009edb / maxColumns 5.
+            const theme = resolveTheme({}, { color: { primary: '#7b6f82' }, megaMenu: { maxColumns: 2 } })
+
+            expect(theme.color.primary).toBe('#7b6f82')
+            expect(theme.megaMenu.maxColumns).toBe(2)
+        })
+
+        it('outranks all three at once on the same leaf', () => {
+            const config = { theme: { color: { primary: '#222222' } }, runTime: { theme: networkTheme } }
+            const theme  = resolveTheme(config, { color: { primary: '#7b6f82' } })
+
+            expect(theme.color.primary).toBe('#7b6f82')
+            expect(theme.color.primary).not.toBe(networkTheme.color.primary)
+        })
+    })
+
+    describe('per-leaf merge — authoring one leaf never wipes its siblings', () => {
+
+        it('an authored color.primary leaves color.secondary on the network leg', () => {
+            const theme = resolveTheme(siteConfig, { color: { primary: '#7b6f82' } })
+
+            expect(theme.color.primary).toBe('#7b6f82')
+            expect(theme.color.secondary).toBe(networkTheme.color.secondary)
+        })
+
+        it('an authored color group leaves every other group on the network leg', () => {
+            const theme = resolveTheme(siteConfig, { color: { primary: '#7b6f82' } })
+
+            expect(theme.backGround.secondary).toBe(networkTheme.backGround.secondary)
+            expect(theme.megaMenu.maxRowsPerColumn).toBe(networkTheme.megaMenu.maxRowsPerColumn)
+            expect(theme.i18n.maxLangBeforeWrap).toBe(networkTheme.i18n.maxLangBeforeWrap)
+            expect(theme.homePageWidgets.columns).toEqual(networkTheme.homePageWidgets.columns)
+        })
+
+        it('passes non-contract leaves through from the lower leg', () => {
+            const theme = resolveTheme(siteConfig, { color: { primary: '#7b6f82' } })
+
+            // Live key, read at app/composables/theme.js:19 but absent from the ratified authored
+            // list. The per-leaf union carries it through untouched.
+            expect(theme.color.secondaryTextOver).toBe(networkTheme.color.secondaryTextOver)
+            expect(theme.text.primary).toBe(networkTheme.text.primary)
+        })
+
+        it('accepts a non-contract leaf when the author does supply one', () => {
+            const theme = resolveTheme(siteConfig, { color: { secondaryTextOver: '#000000' } })
+
+            expect(theme.color.secondaryTextOver).toBe('#000000')
+            expect(theme.color.primary).toBe(networkTheme.color.primary)
+        })
+    })
+
+    describe('absence is fall-through, never a throw', () => {
+
+        const absent: [string, any][] = [
+            ['undefined (no biolandSettings at all)', undefined],
+            ['null', null],
+            ['an empty theme object', {}],
+            ['a non-object scalar', 'nonsense'],
+            ['an array', []]
+        ]
+
+        for (const [label, authored] of absent) {
+            it(`resolves identically to the three-leg baseline when the authored leg is ${label}`, () => {
+                expect(() => resolveTheme(siteConfig, authored)).not.toThrow()
+
+                // Byte-identical to p01-01's output — the unseeded fleet renders exactly as today.
+                expect(resolveTheme(siteConfig, authored)).toEqual(resolveTheme(siteConfig))
+            })
+        }
+
+        it('does not throw when BOTH the config and the authored leg are missing', () => {
+            expect(() => resolveTheme(undefined, undefined)).not.toThrow()
+            expect(resolveTheme(undefined, undefined)).toEqual(resolveTheme(undefined))
+        })
+
+        it('falls through leaf by leaf, not group by group, when only part is authored', () => {
+            const theme = resolveTheme(siteConfig, { megaMenu: { maxColumns: 2 } })
+
+            expect(theme.megaMenu.maxColumns).toBe(2)
+            expect(theme.megaMenu.forums).toBe(networkTheme.megaMenu.forums)
+            expect(theme.megaMenu.horizontalCardMax).toBe(networkTheme.megaMenu.horizontalCardMax)
+        })
+    })
+
+    describe('empty is not authority', () => {
+
+        it('an empty authored group does not blank a populated lower group', () => {
+            const theme = resolveTheme(siteConfig, { color: {}, megaMenu: {} })
+
+            expect(theme.color.primary).toBe(networkTheme.color.primary)
+            expect(theme.color.secondary).toBe(networkTheme.color.secondary)
+            expect(theme.megaMenu.maxColumns).toBe(networkTheme.megaMenu.maxColumns)
+        })
+
+        it('and the reverse — an empty LOWER group does not blank a populated authored group', () => {
+            const config = { theme: { color: {} }, runTime: { theme: { color: {} } } }
+            const theme  = resolveTheme(config, { color: { primary: '#7b6f82', secondary: '#889262' } })
+
+            expect(theme.color.primary).toBe('#7b6f82')
+            expect(theme.color.secondary).toBe('#889262')
+        })
+
+        it('an authored group of only empty groups is a whole-object no-op', () => {
+            expect(resolveTheme(siteConfig, { color: {}, backGround: {}, i18n: {} }))
+                .toEqual(resolveTheme(siteConfig))
+        })
+    })
+
+    describe('falsy-but-meaningful authored values survive (presence, not truthiness)', () => {
+
+        it('keeps an authored maxRowsPerColumn of 0 instead of falling through to 6', () => {
+            const theme = resolveTheme(siteConfig, { megaMenu: { maxRowsPerColumn: 0 } })
+
+            expect(theme.megaMenu.maxRowsPerColumn).toBe(0)
+        })
+
+        it('keeps an authored forums of false instead of falling through to true', () => {
+            const theme = resolveTheme(siteConfig, { megaMenu: { forums: false } })
+
+            expect(theme.megaMenu.forums).toBe(false)
+        })
+
+        it('keeps an authored backGround.secondary of empty string — its old read had no ||', () => {
+            const theme = resolveTheme(siteConfig, { backGround: { secondary: '' } })
+
+            expect(theme.backGround.secondary).toBe('')
+        })
+    })
+
+    describe('LEAF_VALIDATORS still apply to the authored leg — unusable falls through', () => {
+
+        it('an authored empty color.primary falls through to the network value', () => {
+            const theme = resolveTheme(siteConfig, { color: { primary: '   ' } })
+
+            expect(theme.color.primary).toBe(networkTheme.color.primary)
+        })
+
+        it('an authored non-string color.secondary falls through to the network value', () => {
+            const theme = resolveTheme(siteConfig, { color: { secondary: 42 } })
+
+            expect(theme.color.secondary).toBe(networkTheme.color.secondary)
+        })
+
+        it('an authored megaMenu.maxColumns of 0 falls through — 0 collapses the grid', () => {
+            const theme = resolveTheme(siteConfig, { megaMenu: { maxColumns: 0 } })
+
+            expect(theme.megaMenu.maxColumns).toBe(networkTheme.megaMenu.maxColumns)
+        })
+
+        it('falls through only the unusable leaf, keeping its usable siblings', () => {
+            const theme = resolveTheme(siteConfig, { color: { primary: '', secondary: '#889262' } })
+
+            expect(theme.color.primary).toBe(networkTheme.color.primary)
+            expect(theme.color.secondary).toBe('#889262')
+        })
+    })
+
+    describe('hero — derived only when absent from every source', () => {
+
+        it('derives from the AUTHORED colors when no leg authors a hero', () => {
+            const config = { runTime: { theme: { color: networkTheme.color } } }
+            const theme  = resolveTheme(config, { color: { primary: '#7b6f82', secondary: '#889262' } })
+
+            expect(theme.hero.primary).toEqual(['#7b6f82', '#889262'])
+        })
+
+        it('preserves an authored hero.primary[1] of #CBB279 rather than re-deriving it', () => {
+            const theme = resolveTheme(siteConfig, {
+                color: { primary: '#7b6f82', secondary: '#889262' },
+                hero : { primary: ['#7b6f82', '#CBB279'] }
+            })
+
+            expect(theme.hero.primary).toEqual(['#7b6f82', '#CBB279'])
+        })
+
+        it('fills only the missing slot of a partially authored hero', () => {
+            const theme = resolveTheme(siteConfig, {
+                color: { primary: '#7b6f82', secondary: '#889262' },
+                hero : { primary: [null, '#CBB279'] }
+            })
+
+            expect(theme.hero.primary).toEqual(['#7b6f82', '#CBB279'])
+        })
+    })
+
+    describe('untrusted input — prototype-aliasing keys are dropped', () => {
+
+        /**
+         * Non-vacuous by construction. Each payload below THROWS on the unguarded resolver, so the
+         * assertions genuinely distinguish guarded from unguarded. Verified on the pre-guard tree:
+         *
+         *   { megaMenu: { __proto__ } }  -> TypeError: isUsable is not a function
+         *        LEAF_VALIDATORS.megaMenu['__proto__'] inherits Object.prototype: truthy, not callable.
+         *   { __proto__ } at top level   -> TypeError: (CONTRACT_LEAVES[group] || []) is not iterable
+         *        CONTRACT_LEAVES['__proto__'] inherits Object.prototype, so `|| []` never fires.
+         *   { constructor } at top level -> same TypeError.
+         *
+         * The payloads are nested under real, resolvable keys and every case asserts on a resolved
+         * leaf, so a guard that merely stopped the throw without still resolving would also fail.
+         */
+        const hostile = (json: string) => JSON.parse(json)
+
+        it('survives a __proto__ leaf nested under a known group, and still resolves', () => {
+            const theme = resolveTheme(siteConfig, hostile('{"megaMenu":{"__proto__":{"polluted":"yes"},"maxColumns":4}}'))
+
+            expect(theme.megaMenu.maxColumns).toBe(4)
+            expect(theme.megaMenu).not.toHaveProperty('__proto__')
+            expect(({} as any).polluted).toBeUndefined()
+        })
+
+        it('survives a constructor leaf nested under a known group, and still resolves', () => {
+            const theme = resolveTheme(siteConfig, hostile('{"megaMenu":{"constructor":{"polluted":"yes"},"maxColumns":4}}'))
+
+            expect(theme.megaMenu.maxColumns).toBe(4)
+            expect(Object.prototype.hasOwnProperty.call(theme.megaMenu, 'constructor')).toBe(false)
+        })
+
+        it('survives a top-level __proto__ group, and still resolves the real groups', () => {
+            const theme = resolveTheme(siteConfig, hostile('{"__proto__":{"polluted":"yes"},"color":{"primary":"#7b6f82"}}'))
+
+            expect(theme.color.primary).toBe('#7b6f82')
+            expect(({} as any).polluted).toBeUndefined()
+        })
+
+        it('survives a top-level constructor group, and still resolves the real groups', () => {
+            const theme = resolveTheme(siteConfig, hostile('{"constructor":{"polluted":"yes"},"color":{"primary":"#7b6f82"}}'))
+
+            expect(theme.color.primary).toBe('#7b6f82')
+            expect(Object.prototype.hasOwnProperty.call(theme, 'constructor')).toBe(false)
+        })
+
+        it('survives a prototype key nested deeper, inside a cloned value', () => {
+            const theme = resolveTheme(siteConfig, hostile('{"homePageWidgets":{"news":{"prototype":{"polluted":"yes"},"on":true}}}'))
+
+            expect(theme.homePageWidgets.news).toEqual({ on: true })
+            expect(({} as any).polluted).toBeUndefined()
+        })
+
+        it('drops hostile keys on the lower legs too — trust level is not assumed per leg', () => {
+            const config = { runTime: { theme: hostile('{"megaMenu":{"__proto__":{"p":1},"maxColumns":3}}') } }
+
+            expect(() => resolveTheme(config, undefined)).not.toThrow()
+            expect(resolveTheme(config, undefined).megaMenu.maxColumns).toBe(3)
+        })
+    })
+
+    describe('effective-value fixture cases', () => {
+        const fixture = effectiveValues as any
+
+        for (const testCase of fixture.cases) {
+            it(testCase.name, () => {
+                const config: any = { runTime: { theme: fixture.networkTheme } }
+
+                if (testCase.siteTheme) config.theme = testCase.siteTheme
+
+                const theme = resolveTheme(config, testCase.authoredTheme)
+
+                for (const [path, expected] of Object.entries(testCase.expected)) {
+                    if (path.startsWith('_comment')) continue
+                    const actual = path.split('.').reduce((node: any, key) => node?.[key], theme)
+
+                    expect(actual, `${testCase.name} -> ${path}`).toEqual(expected)
+                }
+            })
+        }
+
+        it('contains no snake_case theme key — head fixtures are post-camelCase only', () => {
+            expect(JSON.stringify(fixture.cases)).not.toMatch(/"[a-z]+(_[a-z]+)+"\s*:/)
+        })
+    })
+
+    describe('result is never aliased to the authored input', () => {
+
+        it('mutating the resolved theme cannot corrupt the authored settings', () => {
+            const authored: any = { color: { primary: '#7b6f82' }, homePageWidgets: { columns: [['panorama']] } }
+            const theme         = resolveTheme(siteConfig, authored)
+
+            theme.color.primary = '#000000'
+            theme.homePageWidgets.columns[0].push('gbif')
+
+            expect(authored.color.primary).toBe('#7b6f82')
+            expect(authored.homePageWidgets.columns).toEqual([['panorama']])
+        })
     })
 })

--- a/tests/unit/server/utils/bioland-settings-camel-case.test.ts
+++ b/tests/unit/server/utils/bioland-settings-camel-case.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { camelCase } from 'change-case/keys'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Transform pin — depth 7, one of the two depths this task must keep separate.
+ *
+ * Drupal authors snake_case. dmsm hands those keys through untouched: its SQL is an exact match on
+ * `name = 'bioland.settings'` and it assigns the whole config object onto
+ * `siteConfig.runTime.biolandSettings` without iterating keys. So the head owns every bit of case
+ * conversion, and `app/utils/resolve-theme.js` only ever sees camelCase.
+ *
+ * ## Why this file pins the transform and not the context builder
+ *
+ * `server/utils/context-unified.ts` camelCases `biolandSettings` in TWO places:
+ *
+ *   L352  `biolandSettings: config?.runTime?.biolandSettings ? camelCase(..., 7) || {} : {}`
+ *         — a field of the object literal the builder RETURNS. This is the live path. It is the
+ *         copy that reaches the app as `siteStore.biolandSettings`, and it is what the resolver's
+ *         authored leg is fed from.
+ *
+ *   L354  `if (config?.runTime?.biolandSettings) config.runTime.biolandSettings = camelCase(...)`
+ *         — sits AFTER the `return` that closes at L353, so it never executes. Dead code, pending
+ *         local deletion.
+ *
+ * This suite must pass whether or not L354 exists. It therefore never imports or executes the
+ * context builder. It pins the transform behaviourally through the same `camelCase` import the
+ * live line uses, and pins the live call's shape by reading the source of the RETURNED field only.
+ * Deleting L354 changes neither assertion.
+ */
+describe('bioland.settings depth-7 camelCase transform', () => {
+
+    /** Author-shaped payload: the snake_case keys a Drupal editor writes under `theme`. */
+    const authored = {
+        theme: {
+            color            : { primary: '#7b6f82', secondary: '#889262' },
+            back_ground      : { secondary: '#F2F2F2' },
+            home_page_widgets: { columns: [['panorama', 'gbif'], ['implementation'], ['forums']] },
+            mega_menu        : { forums: false, max_columns: 4, max_rows_per_column: 0, horizontal_card_max: 3 },
+            i18n             : { max_lang_before_wrap: 6 }
+        }
+    }
+
+    it('converts back_ground to backGround — the key the resolver reads', () => {
+        const transformed: any = camelCase(authored, 7)
+
+        expect(transformed.theme.backGround.secondary).toBe('#F2F2F2')
+        expect(transformed.theme).not.toHaveProperty('back_ground')
+    })
+
+    it('converts every authored theme group and leaf in the ratified key list', () => {
+        const theme: any = (camelCase(authored, 7) as any).theme
+
+        expect(Object.keys(theme).sort()).toEqual(['backGround', 'color', 'homePageWidgets', 'i18n', 'megaMenu'])
+
+        expect(theme.color).toEqual({ primary: '#7b6f82', secondary: '#889262' })
+        expect(theme.megaMenu).toEqual({ forums: false, maxColumns: 4, maxRowsPerColumn: 0, horizontalCardMax: 3 })
+        expect(theme.i18n).toEqual({ maxLangBeforeWrap: 6 })
+    })
+
+    it('preserves falsy-but-meaningful authored values through the transform', () => {
+        const theme: any = (camelCase(authored, 7) as any).theme
+
+        // `0` means "unlimited" and `false` means "hide forums". Neither may be dropped or coerced.
+        expect(theme.megaMenu.maxRowsPerColumn).toBe(0)
+        expect(theme.megaMenu.forums).toBe(false)
+    })
+
+    it('reaches deep enough for the nested columns sequence', () => {
+        const theme: any = (camelCase(authored, 7) as any).theme
+
+        expect(theme.homePageWidgets.columns).toEqual([['panorama', 'gbif'], ['implementation'], ['forums']])
+    })
+
+    it('leaves an absent bioland.settings alone rather than inventing one', () => {
+        expect(camelCase({}, 7)).toEqual({})
+    })
+
+    /**
+     * Source-shape pin, scoped to the RETURNED field only.
+     *
+     * Asserts the live path still camelCases at depth 7. It matches the `biolandSettings:` object
+     * literal field — the L352 form, with a colon — so the dead L354 assignment (`... =` after an
+     * `if`) can be deleted without touching this assertion.
+     */
+    it('camelCases at depth 7 on the returned biolandSettings field, independent of the dead line', () => {
+        const source = readFileSync(resolve(__dirname, '../../../../server/utils/context-unified.ts'), 'utf8')
+
+        const returnedField = source
+            .split('\n')
+            .filter(line => /^\s*biolandSettings\s*:/.test(line))
+
+        expect(returnedField).toHaveLength(1)
+        expect(returnedField[0]).toMatch(/camelCase\(\s*config\.runTime\.biolandSettings\s*,\s*7\s*\)/)
+    })
+})


### PR DESCRIPTION
### Problem

Drupal editors can author a theme into `bioland.settings.theme`, and dmsm already carries the whole object through to head. Head ignored it. No site's authored theme reached the front end at all.

### Resolution

Add `biolandSettings.theme` as the resolver's first precedence leg, merged per leaf. It ships dark — no site currently holds authored theme data, so nothing renders differently until an editor saves one and this deploys.

### Evidence

Tests 376 to 431, all 55 new passing, failure set unchanged. Resolver coverage 100% statements, 97% branches. The dmsm gate was re-verified live before any code. Code review Approve with comments, security Approve with comments, 2 cycles. Both reviewers mutation-tested or independently reproduced their conclusions.

<details><summary>Full details</summary>

**Jira:** [BL-885](https://scbd.atlassian.net/browse/BL-885) (epic [BL-880](https://scbd.atlassian.net/browse/BL-880))

**Base:** this branches from [BL-881](https://scbd.atlassian.net/browse/BL-881), a genuine compile dependency — it extends the resolver that PR creates. GitHub retargets it to `bsl-2026-04` automatically once #75 merges.

## The dmsm gate

Re-verified live before writing any code. dmsm still passes the whole object through, no allowlist:

```js
const biolandSettings = await getConfigObject(ctx, 'bioland.settings')
siteConfig.runTime.biolandSettings = biolandSettings
```

Live `prod/bl2/be` and `prod/bl2/mk` each return 20 non-curated keys, snake_case preserved, including Drupal-internal `_core`. **`theme` is absent on both**, which is the evidence that this ships dark. dmsm is untouched — head does all the case conversion.

## Security: this opens a new untrusted-input path

Until now theme values came from site config. After this, anyone with editor rights on a site controls an object that drives rendering on every page of that site. Both the security review and the fixes below take that seriously.

**Prototype keys.** Three payloads crashed the unguarded resolver, each proven red and each reachable from authored input via `JSON.parse`:

| Payload | Crash |
| --- | --- |
| `{"megaMenu":{"__proto__":…}}` | `TypeError: isUsable is not a function` |
| `{"__proto__":…}` | `TypeError: (CONTRACT_LEAVES[group] \|\| []) is not iterable` |
| `{"constructor":…}` | same |

The theme is read on every page, so each was a total render failure triggerable from the CMS admin UI. `safeKeys` now filters all three ingestion points.

This is denial of service, **not** prototype pollution — `Object.fromEntries` uses CreateDataProperty, which defines own properties without invoking the `__proto__` setter. Both reviewers verified `Object.prototype` stayed unmodified in every run, guarded and unguarded.

The guard is load-bearing rather than belt-and-braces: `change-case` rewrites a *top-level* `__proto__` to `proto`, but leaves `constructor` verbatim and stops at depth 7.

**Editor-driven render DoS, found in review.** `home-chm.vue:32` does `v-for` over `theme.homePageWidgets.columns`, and Vue's `v-for` over a number renders that many nodes. `homePageWidgets` had no contract leaf and no validator, so an authored `home_page_widgets: { columns: <a very large number> }` would have hung or OOM'd the home page, SSR included. Fixed by adding the contract leaf plus an `Array.isArray` validator, so non-arrays fall through. The boundary test transcribes the template expression verbatim and checks a very large number, a 1000-character string, that same number as a string, an object carrying a huge `length`, and `true`.

**No injection surface.** Every consumer is a Vue `:style` **object** binding, so Vue sets each property individually via `setProperty`. A semicolon-bearing string cannot add a second declaration. There is no rule using `var(--bs-primary)` in a `background` shorthand, so the usual CSS-exfiltration path is absent.

## Empty authored columns

Ratified 2026-08-24: an authored `columns: []` **keeps winning** and renders no widgets.

An editor who clears every column means "no widgets"; silently restoring the network's would be the surprising outcome. It matches ADR 0012's presence-not-truthiness rule and the existing precedent that `maxRowsPerColumn: 0` means "unlimited". Any floor belongs in the module's Theme tab as save-time validation, not in the resolver.

This deliberately overrides the task file's original ask that an empty array not replace a populated lower leg. A characterisation test pins the behaviour, and `docs/debt.md` records that ADR 0012's W2a validates the outer length to exactly 3, which is in tension with accepting `[]` at all. That tension is recorded as debt, not resolved here.

## LOC Breakdown

| Category | LOC | Review est. |
| --- | --- | --- |
| Implementation | 129 | 4.4 min |
| Tests | 737 | 15.0 min |
| Docs | 11 | — |
| **Total impl** | 129 | **19 min** |

> **Review estimate:** ~19 min - [methodology](https://gist.github.com/randyhoulahan/d9b22ccebaa37370a57d53f406e012da).

## Verification

| Check | Result |
| --- | --- |
| `yarn test:run` base ([f2e8445](https://github.com/scbd/bioland-head/commit/f2e8445630f80f4d757acb76ba445f21c364e9f2)) | 376 = 17 failed / 359 passed |
| `yarn test:run` after | 431 = 17 failed / 414 passed |
| `theme-precedence` e2e | both specs pass, and fail when the authored leg is neutralised |
| Failure set | unchanged throughout |
| Resolver coverage | 100% stmts, 97.29% branch |
| dmsm modified | no — verified clean |
| Independence vs base | pass |
| lint / typecheck | N/A — no such script in this repo |

The 17 failures are pre-existing on the base branch: `tests/unit/server/middleware/cache-control.test.js` fails with `CACHE_TTL is not defined`.

## Review

Two cycles, and both reviewers went past reading the diff.

- **Code review** — Approve with comments. It mutation-tested the suite: moving the authored leg to third position kills 21 tests, dropping the leg kills 23, exempting leg 0 from validators kills 11, removing the guard kills 6. It rebuilt the unguarded resolver and reproduced all three crashes. It also **physically deleted the dead line** at `context-unified.ts:354` and re-ran — 96/96 pass, no change — then restored it with `git checkout --`. One Minor, two Nits.
- **Security** — Approve with comments. Independently adjudicated and upheld the DoS-not-pollution claim, then found the Medium above. One Medium, one Low.
- **Cycle 2** — all four addressed in [3d445db](https://github.com/scbd/bioland-head/commit/3d445db492915f4dce30f9d284dfa90559e91656), three files, no scope creep.

The pin test survives deletion of the dead line by design, and the review confirmed the plan's line numbers were wrong: the live field is `context-unified.ts:352` and the dead assignment is `:354`, not the `:354`/`:356` the plan claimed.

One consequence handled honestly in cycle 2: giving `homePageWidgets` a contract leaf made two lines in `resolveOpaqueGroup` provably dead. Rather than leave them and take the branch-coverage hit, they were deleted and `CONTRACT_GROUPS` is now derived from `Object.keys(CONTRACT_LEAVES)`, so the invariant is structural instead of coincidental.


## The e2e spec was vacuous, and the gate caught it

`tests/e2e/theme-precedence.test.ts` was authored here but could not run on this branch, so it first executed during the BL-886 verification gate. It failed, and the reason was worse than the failure suggested.

Two defects, one hiding the other:

1. The fixture authored `#7b6f82`, which is already the target tenant's own colour. That assertion would have passed even if injection did nothing.
2. The spec injected into `config.runTime.biolandSettings.theme`, a path `app/stores/site.js` deliberately does not read. Its `theme` getter reads the top-level `biolandSettings` passed through `initialize`, sourced from `/api/context/{siteCode}/{locale}`. Nothing the fixture wrote could ever reach the page.

So **both** specs were passing vacuously, including the fall-through one, which was deleting a key nothing reads.

Fixed in [7897590](https://github.com/scbd/bioland-head/commit/7897590). The spec now intercepts `**/api/context/**`, which the site plugin refetches client-side. It uses a sentinel `color.primary` absent from the tenant's real theme, and asserts at runtime that the sentinel is absent from the captured baseline **before** asserting it took effect, so a future tenant theme that adopts it fails loudly instead of silently making the spec vacuous again.

The fixture originally also carried `megaMenu.maxColumns: 4`, which nothing observed. It was dropped rather than asserted: that leaf has no inline-style projection, and its only DOM effect is structural, gated behind a nav toggle and sourced from a second endpoint this spec does not control. Asserting it would have meant element-count coupling the suite's own rules forbid. The reasoning is recorded in the spec. Cross-group per-leaf merge stays covered by the unit suite.

Discrimination is now proven, not assumed: the spec passes as fixed, and fails with `the authored primary did not reach the rendered page` when the authored leg is neutralised.

No application code changed. `app/utils/resolve-theme.js` was not touched.

## Known conflict

This branch and [BL-882](https://scbd.atlassian.net/browse/BL-882) (#73) both create `docs/debt.md`. Neither cherry-picked from the other. Whichever merges second will conflict, and the resolution is to keep both sets of rows.

## Context

Last of five PRs from the `themeing-front-end` plan. The contract it implements is ADR 0012 ([BL-882](https://scbd.atlassian.net/browse/BL-882)); it re-decides nothing. [BL-890](https://scbd.atlassian.net/browse/BL-890) tracks moving the prototype filtering from this consumer to the ingestion boundary, which is the durable fix both security reviews recommended.

</details>


[BL-885]: https://scbd.atlassian.net/browse/BL-885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-880]: https://scbd.atlassian.net/browse/BL-880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-881]: https://scbd.atlassian.net/browse/BL-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-882]: https://scbd.atlassian.net/browse/BL-882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ